### PR TITLE
Blauben/issue/31

### DIFF
--- a/.github/workflows/build-test-cpp.yaml
+++ b/.github/workflows/build-test-cpp.yaml
@@ -20,4 +20,4 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
       - name: Build and test (Linux & macOS)
-        run: cmake --workflow --preset build-and-test
+        run: cmake --workflow --preset build-and-test-release

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -235,8 +235,8 @@
         ]
     },
     {
-      "name": "build-and-test",
-      "displayName": "Build and Test",
+      "name": "build-and-test-release",
+      "displayName": "Build and Test (Release)",
       "steps": [
         {
           "type": "configure",
@@ -253,7 +253,7 @@
       ]
     },
     {
-      "name": "test-debug",
+      "name": "build-and-test-debug",
       "displayName": "Build and Test (Debug)",
       "steps": [
         {

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ print(f"Intersection points: {intersections}")
 tree.printTree()
 ```
 
-## CMake 
-For advanced CMake configuration, refer to the [documentation](docs).
+## CMake
+For advanced CMake configuration and the full preset reference, refer to the [documentation](docs/source/cmake/cmake.rst).
 
 ## Algorithm Comparison
 
@@ -199,4 +199,3 @@ Contributions are welcome! Please feel free to submit issues or pull requests.
 ## Citation
 
 If you use this library in your research, please cite it appropriately.
-

--- a/docs/source/cmake/cmake.rst
+++ b/docs/source/cmake/cmake.rst
@@ -20,7 +20,8 @@ configure/build/test sequence and reduce manual flag drift.
    cmake --workflow --preset build-release-omp
 
    # Test, Python interface, and docs
-   cmake --workflow --preset build-and-test
+   cmake --workflow --preset build-and-test-release
+   cmake --workflow --preset build-and-test-debug
    cmake --workflow --preset build-python-interface
    cmake --workflow --preset build-docs
 
@@ -85,7 +86,9 @@ Configure presets (from ``CMakePresets.json``):
 +----------------+-------------------------------+----------------------------------------------+
 | ``release-tbb``| ``release``                   | Release build with TBB backend.              |
 +----------------+-------------------------------+----------------------------------------------+
-| ``test``       | ``release-tbb``               | Enables tests and sets logging to ``WARN``.  |
+| ``test-release``| ``release-tbb``              | Test build in Release with ``BUILD_KD_TREE_TESTS=ON``. |
++----------------+-------------------------------+----------------------------------------------+
+| ``test-debug`` | ``debug``                     | Test build in Debug with ``BUILD_KD_TREE_TESTS=ON``. |
 +----------------+-------------------------------+----------------------------------------------+
 | ``python``     | ``release``                   | Python interface (CPP backend), CLI off.     |
 +----------------+-------------------------------+----------------------------------------------+
@@ -99,20 +102,22 @@ Configure presets (from ``CMakePresets.json``):
 Build presets:
 
 - ``release``, ``debug``, ``release-omp``, ``release-tbb``
-- ``test``
+- ``test-release``, ``test-debug``
 - ``python-cpp``, ``python-omp``, ``python-tbb``
 - ``docs-build`` (build target: ``Sphinx``)
 
 Test presets:
 
-- ``test``
+- ``test-release``
+- ``test-debug``
 
 Workflow presets:
 
 - ``build-release-default``
 - ``build-release-omp``
 - ``build-release-tbb``
-- ``build-and-test``
+- ``build-and-test-release``
+- ``build-and-test-debug``
 - ``build-python-interface``
 - ``build-docs``
 
@@ -127,7 +132,8 @@ Preferred: run workflows directly:
    cmake --workflow --preset build-release-default
    cmake --workflow --preset build-release-tbb
    cmake --workflow --preset build-release-omp
-   cmake --workflow --preset build-and-test
+   cmake --workflow --preset build-and-test-release
+   cmake --workflow --preset build-and-test-debug
    cmake --workflow --preset build-python-interface
    cmake --workflow --preset build-docs
 
@@ -135,11 +141,5 @@ Alternative: manual configure/build (only when custom flags are needed):
 
 .. code-block:: bash
 
-   cmake -S . -B build/custom \
-     -DCMAKE_BUILD_TYPE=Release \
-     -DKD_TREE_PARALLELIZATION=OMP \
-     -DKD_TREE_LOGGING_LEVEL=INFO \
-     -DBUILD_KD_TREE_EXECUTABLE=ON \
-     -DBUILD_KD_TREE_TESTS=OFF
-
+   cmake -S . -B build/custom -DCMAKE_BUILD_TYPE=Release -DKD_TREE_PARALLELIZATION=OMP -DKD_TREE_LOGGING_LEVEL=INFO -DBUILD_KD_TREE_EXECUTABLE=ON -DBUILD_KD_TREE_TESTS=OFF
    cmake --build build/custom

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -58,19 +58,18 @@ Building the C++ Library
    git clone <repository-url>
    cd kd-tree
 
-   # Create build directory
-   mkdir build && cd build
+   # Recommended: workflow presets
+   cmake --workflow --preset build-release-default
 
-   # Configure with CMake
-   cmake .. -DCMAKE_BUILD_TYPE=Release \
-            -DKD_TREE_PARALLELIZATION=TBB \
-            -DKD_TREE_LOGGING_LEVEL=INFO
+   # Optional variants
+   cmake --workflow --preset build-release-tbb
+   cmake --workflow --preset build-release-omp
+   cmake --workflow --preset build-and-test-release
+   cmake --workflow --preset build-and-test-debug
 
-   # Build
-   cmake --build . --config Release
-
-   # Run tests (optional)
-   ctest --output-on-failure
+   # Optional manual preset path
+   cmake --preset release-tbb
+   cmake --build --preset release-tbb
 
 Installing the Python Package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tests/ctest.rst
+++ b/docs/source/tests/ctest.rst
@@ -9,7 +9,11 @@ Preset-Based Workflow (Recommended)
 
 .. code-block:: bash
 
-   cmake --workflow --preset build-and-test
+   # Release test workflow
+   cmake --workflow --preset build-and-test-release
+
+   # Debug test workflow
+   cmake --workflow --preset build-and-test-debug
 
 Manual Workflow
 ---------------
@@ -26,3 +30,4 @@ Run a Specific CTest Case
 .. code-block:: bash
 
    ctest --test-dir build/test -R KDTree --output-on-failure
+

--- a/src/KDTree/input/TetgenAdapter.cpp
+++ b/src/KDTree/input/TetgenAdapter.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TetgenAdapter.h"
+#include "KDTree/util/Constants.h"
 
 #include <filesystem>
 
@@ -34,7 +35,7 @@ namespace kdtree {
             _tetgenio.load_node(const_cast<char *>(filename.c_str()));
             this->addVertices();
         } catch (...) {
-            throw std::runtime_error(DEFAULT_EXCEPTION_MSG);
+            throw std::runtime_error(constants::TETGEN_DEFAULT_EXCEPTION_MSG);
         }
     }
 
@@ -44,7 +45,7 @@ namespace kdtree {
             _tetgenio.load_face(const_cast<char *>(filename.c_str()));
             this->addFacesByTrifaces();
         } catch (...) {
-            std::string message{DEFAULT_EXCEPTION_MSG};
+            std::string message{constants::TETGEN_DEFAULT_EXCEPTION_MSG};
             message.append(" A second possible issue could be a wrong file order, e.g. the .face file was read before "
                            "the .node file. In this case just reverse the parameters in the input file list.");
             throw std::runtime_error(message);
@@ -57,7 +58,7 @@ namespace kdtree {
             _tetgenio.load_off(const_cast<char *>(filename.c_str()));
             this->addVerticesAndFacesByTriangulation();
         } catch (...) {
-            throw std::runtime_error(DEFAULT_EXCEPTION_MSG);
+            throw std::runtime_error(constants::TETGEN_DEFAULT_EXCEPTION_MSG);
         }
     }
 
@@ -67,7 +68,7 @@ namespace kdtree {
             _tetgenio.load_ply(const_cast<char *>(filename.c_str()));
             this->addVerticesAndFacesByTriangulation();
         } catch (...) {
-            throw std::runtime_error(DEFAULT_EXCEPTION_MSG);
+            throw std::runtime_error(constants::TETGEN_DEFAULT_EXCEPTION_MSG);
         }
     }
 
@@ -77,7 +78,7 @@ namespace kdtree {
             _tetgenio.load_stl(const_cast<char *>(filename.c_str()));
             this->addVerticesAndFacesByTriangulation();
         } catch (...) {
-            throw std::runtime_error(DEFAULT_EXCEPTION_MSG);
+            throw std::runtime_error(constants::TETGEN_DEFAULT_EXCEPTION_MSG);
         }
     }
 
@@ -87,7 +88,7 @@ namespace kdtree {
             _tetgenio.load_medit(const_cast<char *>(filename.c_str()), 0);
             this->addVerticesAndFacesByTriangulation();
         } catch (...) {
-            throw std::runtime_error(DEFAULT_EXCEPTION_MSG);
+            throw std::runtime_error(constants::TETGEN_DEFAULT_EXCEPTION_MSG);
         }
     }
 

--- a/src/KDTree/input/TetgenAdapter.h
+++ b/src/KDTree/input/TetgenAdapter.h
@@ -12,6 +12,7 @@
 #include "tetgen.h"
 
 #include "KDTree/util/UtilityContainer.h"
+#include "KDTree/util/Constants.h"
 #include <array>
 #include <exception>
 #include <functional>
@@ -32,18 +33,10 @@ namespace kdtree {
  */
     class TetgenAdapter {
 
-        /**
-         * The default exception message
-         */
-        static constexpr char DEFAULT_EXCEPTION_MSG[] =
-                "The mesh was not read because of an error in Tetgen! This could indicate several "
-                "issues, e. g. issues with the node assignment like they appear if either no nodes were "
-                "read in at all or if no assignment was possible.";
-
-        /**
-         * Delegates the call to the library tetgen
-         */
-        tetgenio _tetgenio;
+         /**
+          * Delegates the call to the library tetgen
+          */
+         tetgenio _tetgenio;
 
         /**
          * The file names from which to read in the polyhedron

--- a/src/KDTree/model/GeometryObject.cpp
+++ b/src/KDTree/model/GeometryObject.cpp
@@ -3,15 +3,12 @@
 #include <utility>
 
 namespace kdtree {
-    GeometryObject::GeometryObject(IndexVector objVertices) : objIndex{runningIndex++}, objVertices{std::move(objVertices)} {
+    GeometryObject::GeometryObject(IndexVector objVertices, const size_t objIndex, const std::shared_ptr<std::vector<VertexHandle>>& vertices)
+        : objIndex{objIndex}, objVertices{std::move(objVertices)}, _vertices{vertices} {
     }
 
-    //static initialization
-    size_t GeometryObject::runningIndex{0};
-
-    std::vector<VertexHandle> GeometryObject::vertices;
-
     Vertex GeometryObject::operator[](const size_t index) const {
+        const auto &vertices = *_vertices;
         return std::visit(util::overloaded{
                 [&](const Vertex *vertex) { return *vertex; },
                 [&](const Vertex &vertex) { return vertex; }

--- a/src/KDTree/model/GeometryObject.h
+++ b/src/KDTree/model/GeometryObject.h
@@ -17,24 +17,15 @@ namespace kdtree {
     class GeometryObject {
     public:
         /**
-         * This field stores the index of the next GeometryObject and is increased whenever a new Object is increased.
-         */
-        static size_t runningIndex;
-        /**
-         * The global vertices of the scene on which the GeometryObjects are built on.
-         */
-        static std::vector<VertexHandle> vertices;
-
-        /**
          * This index uniquely identifies a GeometryObject during kdtree construction.
          */
         const size_t objIndex;
 
         /**
-         * Stores information on the corner vertices of this GeometryObject by storing their respective indices referencing the static vertices.
+         * Stores indices of this object's corner vertices in the owning KDTree vertex storage.
          */
         const IndexVector objVertices;
-        explicit GeometryObject(IndexVector objVertices);
+        GeometryObject(IndexVector objVertices, size_t objIndex, const std::shared_ptr<std::vector<VertexHandle>> &vertices);
 
         /**
          * Returns the index-th vertex of the shape represented by this GeometryObject.
@@ -55,6 +46,10 @@ namespace kdtree {
          * @return a std::vector of Vertex objects
          */
         [[nodiscard]] std::vector<Vertex> getVertices() const;
+
+    private:
+        // Vertex storage owned by the KDTree instance that created this object.
+        const std::shared_ptr<std::vector<VertexHandle>> _vertices;
     };
 
     /**

--- a/src/KDTree/plane_selection/PlaneSelectionAlgorithm.cpp
+++ b/src/KDTree/plane_selection/PlaneSelectionAlgorithm.cpp
@@ -15,8 +15,8 @@ namespace kdtree {
         const double surfaceArea1 = box1.surfaceArea();
         const double surfaceArea2 = box2.surfaceArea();
         //evaluate SAH: Include equalT once in each box and record option with minimum cost
-        const double costLesser = traverseStepCost + shapeIntersectionCost * (surfaceArea1 / surfaceAreaBounding * static_cast<double>(shapesMin + shapesPlanar) + surfaceArea2 / surfaceAreaBounding * static_cast<double>(shapesMax));
-        const double costGreater = traverseStepCost + shapeIntersectionCost * (surfaceArea1 / surfaceAreaBounding * static_cast<double>(shapesMin) + surfaceArea2 / surfaceAreaBounding * static_cast<double>(shapesMax + shapesPlanar));
+        const double costLesser = constants::TRAVERSE_STEP_COST + constants::SHAPE_INTERSECTION_COST * (surfaceArea1 / surfaceAreaBounding * static_cast<double>(shapesMin + shapesPlanar) + surfaceArea2 / surfaceAreaBounding * static_cast<double>(shapesMax));
+        const double costGreater = constants::TRAVERSE_STEP_COST + constants::SHAPE_INTERSECTION_COST * (surfaceArea1 / surfaceAreaBounding * static_cast<double>(shapesMin) + surfaceArea2 / surfaceAreaBounding * static_cast<double>(shapesMax + shapesPlanar));
         //if empty space is cut off, reduce cost by 20%
         const double factor = shapesMin == 0 || shapesMax == 0 ? 0.8 : 1;
         if (costLesser <= costGreater) {

--- a/src/KDTree/plane_selection/PlaneSelectionAlgorithm.h
+++ b/src/KDTree/plane_selection/PlaneSelectionAlgorithm.h
@@ -11,6 +11,7 @@
 
 #include "KDTree/tree/KdDefinitions.h"
 #include "KDTree/tree/SplitParam.h"
+#include "KDTree/util/Constants.h"
 
 namespace kdtree {
 
@@ -139,18 +140,6 @@ namespace kdtree {
                         std::move(_callbackArgs));
             }
         };
-
-
-        /**
-        * Constant that describes the cost of traversing the KDTree by one step.
-        */
-        constexpr static double traverseStepCost{1.0};
-
-        /**
-        * Constant that describes the cost of intersecting a ray and a single object.
-        */
-        constexpr static double shapeIntersectionCost{1.0};
-
     protected:
         /**
        * Evaluates the cost function should the specified bounding box and it's shapes be divided by the specified plane. Used to evaluate possible split planes.

--- a/src/KDTree/tree/KDTree.cpp
+++ b/src/KDTree/tree/KDTree.cpp
@@ -5,19 +5,21 @@ namespace kdtree {
     KDTree::KDTree(const std::vector<Vertex> &vertices, const std::vector<IndexVector> &shapes,
                    const PlaneSelectionAlgorithm::Algorithm algorithm, const bool copyVertices) : _algorithm{algorithm} {
         LOG_INFO("KDTree: Constructing from vertices and faces");
-        std::for_each(vertices.begin(), vertices.end(), [copyVertices](const Vertex& vertex) {
-            if (copyVertices) {
-                GeometryObject::vertices.emplace_back(vertex);
-            } else {
-                GeometryObject::vertices.emplace_back(&vertex);
-            }
-        });
+        if (copyVertices) {
+            _vertices = std::make_shared<std::vector<VertexHandle>>(vertices.begin(), vertices.end());
+        } else {
+            _vertices = std::make_shared<std::vector<VertexHandle>>();
+            _vertices->reserve(vertices.size());
+            std::for_each(vertices.begin(), vertices.end(), [this, copyVertices](const Vertex &vertex) {
+                _vertices->emplace_back(&vertex);
+            });
+        }
         _geometryObjects.reserve(shapes.size());
         //transform shape indices to GeometryObjects
-        std::ranges::for_each(shapes, [this](const IndexVector &vertexIndices) {
-            _geometryObjects.emplace_back(vertexIndices);
+        std::ranges::for_each(shapes, [this, objectIndex = size_t{0}](const IndexVector &vertexIndices) mutable {
+            _geometryObjects.emplace_back(vertexIndices, objectIndex++, _vertices);
         });
-        _splitParam = std::make_unique<SplitParam>(_geometryObjects, Box::getBoundingBox(vertices), Direction::X,
+        _splitParam = std::make_unique<SplitParam>(_geometryObjects, Box::getBoundingBox(*_vertices), Direction::X,
                                                    PlaneSelectionAlgorithmFactory::create(algorithm));
         LOG_DEBUG("KDTree: Construction complete, split parameters initialized");
     }
@@ -50,7 +52,7 @@ namespace kdtree {
     void KDTree::rebuildTree() {
         this->_rootNode.reset();//reset the root node to allow rebuilding the tree
         // since splitParam are moved once the previous tree is built, they have to regenerated here
-        _splitParam = std::make_unique<SplitParam>(_geometryObjects, Box::getBoundingBox(GeometryObject::vertices), Direction::X,
+        _splitParam = std::make_unique<SplitParam>(_geometryObjects, Box::getBoundingBox(*_vertices), Direction::X,
                                                    PlaneSelectionAlgorithmFactory::create(_algorithm));
     }
 

--- a/src/KDTree/tree/KDTree.h
+++ b/src/KDTree/tree/KDTree.h
@@ -47,6 +47,11 @@ namespace kdtree {
         /**
          * The polyhedron's vertices.
          */
+        std::shared_ptr<std::vector<VertexHandle>> _vertices;
+
+        /**
+         * The polyhedron's geometry objects.
+         */
         std::vector<GeometryObject> _geometryObjects;
 
         /**

--- a/src/KDTree/tree/KdDefinitions.h
+++ b/src/KDTree/tree/KdDefinitions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "KDTree/util/UtilityContainer.h"
+#include "KDTree/util/Constants.h"
 #include "thrust/detail/execution_policy.h"
 #include "thrust/execution_policy.h"
 #include "thrust/system/detail/sequential/for_each.h"
@@ -84,11 +85,6 @@ namespace kdtree {
                 throw std::invalid_argument{"Unknown Direction enum value used during normal fetching."};
         }
     }
-
-    /**
-     * Number of dimensions for the polyhedron. Also corresponds to the number of elements of the {@link Direction} enum.
-     */
-    constexpr int DIMENSIONS = 3;
 
     /**
      * A set that stores indices of the object vector in the KDTree. This effectively corresponds to a set of shapes. For performance purposes a std::vector is used instead of a std::set.

--- a/src/KDTree/tree/LeafNode.cpp
+++ b/src/KDTree/tree/LeafNode.cpp
@@ -1,4 +1,5 @@
 #include "KDTree/tree/LeafNode.h"
+#include "KDTree/util/Constants.h"
 
 namespace kdtree {
     LeafNode::LeafNode(const SplitParam &splitParam, const size_t nodeId)
@@ -28,7 +29,7 @@ namespace kdtree {
             const GeometryObject &object = _splitParam->geometryObjects[handle];
             for (const auto &vertex : object.getVertices()) {
                 // TODO: set tolerance in relation to whole tree
-                if (!_splitParam->boundingBox.isVertexInBox(vertex, 0.5)) {
+                if (!_splitParam->boundingBox.isVertexInBox(vertex, constants::EPSILON_VERTEX_BOX_TOLERANCE)) {
                     return true;
                 }
             }
@@ -86,7 +87,7 @@ namespace kdtree {
         const Vertex edge2 = triangleVertices[2] - triangleVertices[0];
         const Vertex h = cross(rayVector, edge2);
         const double a = dot(edge1, h);
-        if (a > -EPSILON_ZERO_OFFSET && a < EPSILON_ZERO_OFFSET) {
+        if (a > -constants::EPSILON_ZERO_OFFSET && a < constants::EPSILON_ZERO_OFFSET) {
             return std::nullopt;
         }
 
@@ -104,26 +105,25 @@ namespace kdtree {
         }
 
         const double t = f * dot(edge2, q);
-        if (t > EPSILON_ZERO_OFFSET) {
+        if (t > constants::EPSILON_ZERO_OFFSET) {
             return rayOrigin + rayVector * t;
         }
         return std::nullopt;
     }
 
-    std::optional<Vertex> LeafNode::rayIntersectsPoint(const Vertex &rayOrigin, const Vertex &rayVector, const Vertex &center) {
-        using namespace util;
-        constexpr double EPSILON_OFFSET = 1e-2 /* TODO: get radius from object, or use a default small value */;
+     std::optional<Vertex> LeafNode::rayIntersectsPoint(const Vertex &rayOrigin, const Vertex &rayVector, const Vertex &center) {
+         using namespace util;
 
-        // Vector from ray origin to sphere center
-        const Vertex oc = rayOrigin - center;
+         // Vector from ray origin to sphere center
+         const Vertex oc = rayOrigin - center;
 
         // Calculate the nearest intersection point
         const double t = -dot(rayVector, oc) / dot(rayVector, rayVector);
 
         const Vertex intersection = rayOrigin + rayVector * t;
 
-        const double distance = dot(intersection - center, intersection - center);
-        if (distance > EPSILON_OFFSET) {
+         const double distance = dot(intersection - center, intersection - center);
+         if (distance > constants::EPSILON_RAY_POINT_OFFSET) {
             return std::nullopt;
         }
 

--- a/src/KDTree/tree/SplitNode.cpp
+++ b/src/KDTree/tree/SplitNode.cpp
@@ -28,7 +28,7 @@ namespace kdtree {
             },
                        _shapeLists);
             childParam.splitDirection = static_cast<Direction>(
-                    (static_cast<int>(_splitParam->splitDirection) + 1) % DIMENSIONS);
+                    (static_cast<int>(_splitParam->splitDirection) + 1) % constants::DIMENSIONS);
             //increase the recursion depth of the direct child by 1
             node = TreeNodeFactory::createTreeNode(childParam, 2 * nodeId + 1 + index);
             if (_lesser != nullptr && _greater != nullptr) {
@@ -57,7 +57,7 @@ namespace kdtree {
         const double t_split{_plane.rayPlaneIntersection(origin, inverseRay)};
         //the split plane is hit inside of the bounding box -> both child boxes need to be checked
         const bool isParallel = std::isinf(t_split);
-        bool planeIsHitInsideBox = 0 <= t_split && t_enter - EPSILON_NUMERICAL_TOLERANCE <= t_split && t_split <= t_exit + EPSILON_NUMERICAL_TOLERANCE;
+        bool planeIsHitInsideBox = 0 <= t_split && t_enter - constants::EPSILON_NUMERICAL_TOLERANCE <= t_split && t_split <= t_exit + constants::EPSILON_NUMERICAL_TOLERANCE;
         if (!isParallel && planeIsHitInsideBox) {
             LOG_DEBUG("SplitNode: Plane hit inside bounding box for nodeId ", std::to_string(this->nodeId));
             delegates.push_back(getChildNode(0));

--- a/src/KDTree/tree/SplitNode.h
+++ b/src/KDTree/tree/SplitNode.h
@@ -19,6 +19,7 @@
 #include "KDTree/tree/TreeNode.h"
 #include "KDTree/tree/TreeNodeFactory.h"
 #include "KDTree/util/UtilityContainer.h"
+#include "KDTree/util/Constants.h"
 
 namespace kdtree {
     struct SplitParam;
@@ -56,11 +57,6 @@ namespace kdtree {
          * Contains the shape lists for the lesser and greater bounding boxes. {@link ObjectIndexVectors}
         */
         std::variant<ObjectIndexVectors<2>, PlaneEventVectors<2>> _shapeLists;
-
-        /**
-         * Numerical tolerance for ray box intersections. Necessary to handle cases where the intersection ray is almost parallel to the split plane.
-         */
-        static constexpr double EPSILON_NUMERICAL_TOLERANCE = 1e-9;
 
         friend class PlaneIterator;
 

--- a/src/KDTree/tree/TreeNode.cpp
+++ b/src/KDTree/tree/TreeNode.cpp
@@ -1,16 +1,16 @@
 #include "KDTree/tree/TreeNode.h"
 
 #include "KDTree/Info.h"
+#include "KDTree/util/Constants.h"
 
 namespace kdtree {
     TreeNode::TreeNode(const SplitParam &splitParam, const size_t nodeId)
         : nodeId{nodeId}, _splitParam{std::make_unique<SplitParam>(splitParam)} {
         if (KD_TREE_LOGGING_LEVEL == "DEBUG") {
             //debugging output to trace specific geometry objects through the tree
-            constexpr unsigned long geometryIndex = 2124;
             const auto &bound = std::get<ObjectIndexVector>(this->_splitParam->boundObjects);
-            if (std::find(bound.cbegin(), bound.cend(), geometryIndex) != bound.end()) {
-                LOG_DEBUG("Traced geoObject ", geometryIndex, " to Node: ", this->nodeId);
+            if (std::find(bound.cbegin(), bound.cend(), constants::GEOMETRY_INDEX) != bound.end()) {
+                LOG_DEBUG("Traced geoObject ", constants::GEOMETRY_INDEX, " to Node: ", this->nodeId);
             }
         }
     }

--- a/src/KDTree/tree/TreeNodeFactory.cpp
+++ b/src/KDTree/tree/TreeNodeFactory.cpp
@@ -4,7 +4,7 @@ namespace kdtree::TreeNodeFactory {
     std::shared_ptr<TreeNode> createTreeNode(const SplitParam &splitParam, size_t nodeId) {
         LOG_DEBUG("TreeNodeFactory: createTreeNode called for nodeId ", std::to_string(nodeId));
         //avoid splitting after certain tree depth
-        if (recursionDepth(nodeId) >= MAX_RECURSION_DEPTH) {
+        if (recursionDepth(nodeId) >= constants::MAX_RECURSION_DEPTH) {
             LOG_WARN("TreeNodeFactory: Max recursion depth reached, creating LeafNode for nodeId " + std::to_string(nodeId));
             auto leafNode = std::make_shared<LeafNode>(splitParam, nodeId);
             LeafNode::registerLeafNode(leafNode);
@@ -13,7 +13,7 @@ namespace kdtree::TreeNodeFactory {
         const size_t numberOfObjects{countGeometryObjects(splitParam.boundObjects)};
         //find optimal plane splitting this node's bounding box
         auto [plane, planeCost, shapeLists] = splitParam.planeSelectionStrategy->findPlane(splitParam);
-        const double costWithoutSplit = static_cast<double>(numberOfObjects) * PlaneSelectionAlgorithm::shapeIntersectionCost;
+        const double costWithoutSplit = static_cast<double>(numberOfObjects) * constants::SHAPE_INTERSECTION_COST;
 
         // Check if the boxes are divided into smaller regions
         const bool splitFailsToReduceSize = std::isinf(planeCost) || std::visit([numberOfObjects](auto &typeLists) {

--- a/src/KDTree/tree/TreeNodeFactory.h
+++ b/src/KDTree/tree/TreeNodeFactory.h
@@ -12,12 +12,12 @@
 #include "KDTree/tree/SplitNode.h"
 #include "KDTree/tree/SplitParam.h"
 #include "KDTree/tree/TreeNode.h"
+#include "KDTree/util/Constants.h"
 
 namespace kdtree {
     struct SplitParam;
 }// namespace kdtree
 
-constexpr uint8_t MAX_RECURSION_DEPTH{64};
 
 /**
      * Factory class for building TreeNodes. {@link TreeNode}

--- a/src/KDTree/util/Constants.h
+++ b/src/KDTree/util/Constants.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kdtree::constants {
+
+    // ============================================================================
+    // Floating Point Arithmetic Constants
+    // ============================================================================
+
+    /**
+     * The EPSILON used in the polyhedral gravity model to determine a radius around zero/ to use as slight offset.
+     * @related Used to determine if a floating point number is equal to zero as threshold for rounding errors
+     * @related Used for the sgn() function to determine the sign of a double value. Different compilers
+     * produce different results if no EPSILON is applied for the comparison!
+     */
+    constexpr double EPSILON_ZERO_OFFSET = 1e-14;
+
+    /**
+     * This relative EPSILON is utilized ONLY for testing purposes to compare intermediate values to
+     * Tsoulis' reference implementation Fortran.
+     * It is used in the {@link kdtree::util::almostEqualRelative} function.
+     *
+     * @note While in theory no difference at all is observed when compiling this program on Linux using GCC on x86_64,
+     *  the intermediate values change when the program is compiled in different environments.
+     *  Hence, this solves the flakiness of the tests when on different plattforms
+     */
+    constexpr double EPSILON_ALMOST_EQUAL = 1e-10;
+
+    /**
+     * The maximal allowed ULP distance utilized for FloatingPoint comparisons using the
+     * {@link kdtree::util::almostEqualUlps} function.
+     *
+     * @see https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+     */
+    constexpr int MAX_ULP_DISTANCE = 4;
+
+    // ============================================================================
+    // Spatial/Tree Constants
+    // ============================================================================
+
+    /**
+     * Number of dimensions for the polyhedron. Also corresponds to the number of elements of the {@link Direction} enum.
+     */
+    constexpr int DIMENSIONS = 3;
+
+    /**
+     * Maximum recursion depth for the KDTree. Used to limit the depth and size of the tree.
+     */
+    constexpr uint8_t MAX_RECURSION_DEPTH = 64;
+
+    /**
+     * Numerical tolerance for ray box intersections. Necessary to handle cases where the intersection ray is almost parallel to the split plane.
+     */
+    constexpr double EPSILON_NUMERICAL_TOLERANCE = 1e-9;
+
+    // ============================================================================
+    // Plane Selection Algorithm Constants
+    // ============================================================================
+
+    /**
+     * Constant that describes the cost of traversing the KDTree by one step.
+     */
+    constexpr double TRAVERSE_STEP_COST = 1.0;
+
+    /**
+     * Constant that describes the cost of intersecting a ray and a single object.
+     */
+    constexpr double SHAPE_INTERSECTION_COST = 1.0;
+
+    // ============================================================================
+    // Ray-Geometry Intersection Constants
+    // ============================================================================
+
+    /**
+     * Tolerance offset for ray-point intersection testing.
+     * Used when intersecting rays with point geometry (spheres).
+     */
+    constexpr double EPSILON_RAY_POINT_OFFSET = 1e-2;
+
+    /**
+     * Tolerance offset for vertex containment checks in bounding boxes.
+     * Used in needTreeRebuild() to check if vertices are within their expected bounding box.
+     */
+    constexpr double EPSILON_VERTEX_BOX_TOLERANCE = 0.5;
+
+    // ============================================================================
+    // TetgenAdapter Constants
+    // ============================================================================
+
+    /**
+     * The default exception message for TetgenAdapter errors
+     */
+    constexpr char TETGEN_DEFAULT_EXCEPTION_MSG[] =
+            "The mesh was not read because of an error in Tetgen! This could indicate several "
+            "issues, e. g. issues with the node assignment like they appear if either no nodes were "
+            "read in at all or if no assignment was possible.";
+
+    /**
+     * Geometry index used as a unique identifier in certain contexts
+     */
+    constexpr unsigned long GEOMETRY_INDEX = 2124;
+
+    /**
+     * Maximum exponent difference for floating point operations in container utilities
+     */
+    constexpr int MAX_EXPONENT_DIFFERENCE = 50;
+
+}  // namespace kdtree
+

--- a/src/KDTree/util/UtilityContainer.h
+++ b/src/KDTree/util/UtilityContainer.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <functional>
 #include <iostream>
+#include "Constants.h"
 #include <numeric>
 #include <set>
 #include <string>
@@ -343,11 +344,10 @@ namespace kdtree::util {
     template<typename T>
     bool isCriticalDifference(const T &first, const T &second) {
         // 50 is the (log2) exponent of the floating point (1 / 1e-15)
-        constexpr int maxExponentDifference = 50;
         int x, y;
         std::frexp(first, &x);
         std::frexp(second, &y);
-        return std::abs(x - y) > maxExponentDifference;
+        return std::abs(x - y) > constants::MAX_EXPONENT_DIFFERENCE;
     }
 
     /**

--- a/src/KDTree/util/UtilityFloatArithmetic.h
+++ b/src/KDTree/util/UtilityFloatArithmetic.h
@@ -14,35 +14,9 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "KDTree/util/Constants.h"
+
 namespace kdtree::util {
-
-    /**
-     * The EPSILON used in the polyhedral gravity model to determine a radius around zero/ to use as slight offset.
-     * @related Used to determine if a floating point number is equal to zero as threshold for rounding errors
-     * @related Used for the sgn() function to determine the sign of a double value. Different compilers
-     * produce different results if no EPSILON is applied for the comparison!
-     */
-    constexpr double EPSILON_ZERO_OFFSET = 1e-14;
-
-    /**
-     * This relative EPSILON is utilized ONLY for testing purposes to compare intermediate values to
-     * Tsoulis' reference implementation Fortran.
-     * It is used in the {@link kdtree::util::almostEqualRelative} function.
-     *
-     * @note While in theory no difference at all is observed when compiling this program on Linux using GCC on x86_64,
-     *  the intermediate values change when the program is compiled in different environments.
-     *  Hence, this solves the flakiness of the tests when on different plattforms
-     */
-    constexpr double EPSILON_ALMOST_EQUAL = 1e-10;
-
-    /**
-     * The maximal allowed ULP distance utilized for FloatingPoint comparisons using the
-     * {@link kdtree::util::almostEqualUlps} function.
-     *
-     * @see https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
-     */
-    constexpr int MAX_ULP_DISTANCE = 4;
-
 
     /**
      * Function for comparing closeness of two floating point numbers using ULP (Units in the Last Place) method.
@@ -60,7 +34,7 @@ namespace kdtree::util {
      * @see https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
      */
     template<typename FloatType>
-    bool almostEqualUlps(FloatType lhs, FloatType rhs, int ulpDistance = MAX_ULP_DISTANCE);
+    bool almostEqualUlps(FloatType lhs, FloatType rhs, int ulpDistance = constants::MAX_ULP_DISTANCE);
 
     /**
      * Function to check if two floating point numbers are relatively equal to each other within a given error range or tolerance.
@@ -76,7 +50,7 @@ namespace kdtree::util {
      * @see https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
      */
     template<typename FloatType>
-    bool almostEqualRelative(FloatType lhs, FloatType rhs, double epsilon = EPSILON_ALMOST_EQUAL);
+    bool almostEqualRelative(FloatType lhs, FloatType rhs, double epsilon = constants::EPSILON_ALMOST_EQUAL);
 
 
 }// namespace kdtree::util

--- a/test/model/KDTreeTest.cpp
+++ b/test/model/KDTreeTest.cpp
@@ -308,6 +308,9 @@ namespace kdtree {
         std::vector<IndexVector> faces;
         Algorithm algorithm;
         std::tie(vertices, faces, algorithm, std::ignore) = GetParam();
+        if (algorithm == Algorithm::QUADRATIC || algorithm == Algorithm::NOTREE) {
+            GTEST_SKIP() << "Skipping regression test for notree and quadratic algorithm as it is used as the reference algorithm.";
+        }
         KDTree tree{vertices, faces, algorithm};
         auto squaredAlgorithm = PlaneSelectionAlgorithmFactory::create(Algorithm::QUADRATIC);
         auto variantAlgorithm = PlaneSelectionAlgorithmFactory::create(algorithm);

--- a/test/model/KDTreeTest.cpp
+++ b/test/model/KDTreeTest.cpp
@@ -235,18 +235,7 @@ namespace kdtree {
      * @class KDTreeTest
      * @brief Test suite for the KDTree class functionality.
      */
-    class KDTreeTest : public ::testing::TestWithParam<ParamType> {
-    protected:
-        void SetUp() override {
-            GeometryObject::runningIndex = 0;
-            GeometryObject::vertices.clear();
-        }
-
-        void TearDown() override {
-            GeometryObject::runningIndex = 0;
-            GeometryObject::vertices.clear();
-        }
-    };
+    class KDTreeTest : public ::testing::TestWithParam<ParamType> {};
 
     /**
      * Tests the intersection of rays with points on the surface of a polyhedron using the KDTree. The test generates random points on the surface of the polyhedron and checks if the KDTree correctly identifies the intersection points when rays are cast from a fixed origin towards these points. The test uses a progress bar to track the progress of testing multiple points.

--- a/test/python/test_kdtree.py
+++ b/test/python/test_kdtree.py
@@ -51,4 +51,4 @@ def test_kdtree_plane_iter():
     plane_count = 0
     for _ in tree.planes():
         plane_count += 1
-    assert plane_count == 30, "Expected at least one plane in the KDTree. Iterator returned none."
+    assert plane_count == 30, "Expected 30 planes in the KDTree. Iterator returned none."

--- a/test/python/test_plot.py
+++ b/test/python/test_plot.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 
 def test_plot_no_throw():
     import scikdtree as sci
@@ -6,3 +7,7 @@ def test_plot_no_throw():
     tree = sci.KDTree(mesh_path + ".node", mesh_path + ".face")
     sci.plot_kd_tree(tree, outpath="kd_tree_plot_test.png")
     assert os.path.exists("kd_tree_plot_test.png"), "Plot file was not created as expected."
+    with open("kd_tree_plot_test.png", "rb") as image:
+        file_hash = hashlib.sha256(image.read()).hexdigest()
+    expected_hash = "64b68383dbcc4035f9d62050b90c68bf26f855e690c81c5dc1b2caf11c441875"
+    assert file_hash == expected_hash


### PR DESCRIPTION
- **Enhance: Make python tests more constrictive**
- **Bugfix: Remove all static code parts to enable multiple KDTree instances at the same time and to couple state to each instance.**
- **Enhance: Skip semantically unnecessary test runs to save time**
