### PR TITLE
bug/43 doc images

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -108,15 +108,10 @@
     {
       "name": "docs",
       "displayName": "Documentation",
-      "inherits": "base",
+      "inherits": "python",
       "binaryDir": "${sourceDir}/build/docs",
       "cacheVariables": {
-        "BUILD_KD_TREE_DOCS": "ON",
-        "BUILD_KD_TREE_LIBRARY": "OFF",
-        "BUILD_KD_TREE_EXECUTABLE": "OFF",
-        "BUILD_KD_TREE_PYTHON_INTERFACE": "OFF",
-        "BUILD_KD_TREE_TESTS": "OFF",
-        "BUILD_KD_TREE_TIME_MEASUREMENT": "OFF"
+        "BUILD_KD_TREE_DOCS": "ON"
       }
     }
   ],

--- a/cmake/clang_format.cmake
+++ b/cmake/clang_format.cmake
@@ -10,9 +10,9 @@ find_program(CLANG_FORMAT clang-format)
 
 # Ensure clang-format was found
 if(NOT CLANG_FORMAT)
-    message(STATUS "HPCLab: clang-format not found. Please install it to use clang-format via CMake")
+    message(STATUS "clang-format not found. Please install it to use clang-format via CMake")
 elseif(NOT TARGET format)
-    message(STATUS "HPCLab: clang-format found. You can format all source files via `cmake --build . --target format`")
+    message(STATUS "clang-format found. You can format all source files via `cmake --build . --target format`")
     add_custom_command(
             OUTPUT format_all_files
             COMMAND ${CLANG_FORMAT} -i ${CLANG_FORMAT_SRC}

--- a/cmake/pyvenv.cmake
+++ b/cmake/pyvenv.cmake
@@ -1,0 +1,37 @@
+set(VENV_DIR "${KD_TREE_SOURCE_DIR}/.venv")
+
+# Cross-platform virtual environment paths
+if(WIN32)
+    set(VENV_BIN_DIR "${VENV_DIR}/Scripts")
+    set(VENV_PYTHON "${VENV_BIN_DIR}/python.exe")
+    set(VENV_SPHINX "${VENV_BIN_DIR}/sphinx-build.exe")
+else()
+    set(VENV_BIN_DIR "${VENV_DIR}/bin")
+    set(VENV_PYTHON "${VENV_BIN_DIR}/python")
+    set(VENV_SPHINX "${VENV_BIN_DIR}/sphinx-build")
+endif()
+
+if(NOT EXISTS "${VENV_DIR}")
+    message(STATUS "Creating Python virtual environment at ${VENV_DIR}")
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" -m venv "${VENV_DIR}"
+        RESULT_VARIABLE VENV_CREATE_RESULT
+    )
+    if(NOT VENV_CREATE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to create virtual environment")
+    endif()
+
+    # Install required packages
+    execute_process(
+        COMMAND "${VENV_PYTHON}" -m pip install --upgrade pip
+        RESULT_VARIABLE PIP_UPGRADE_RESULT
+        OUTPUT_VARIABLE PIP_UPGRADE_OUTPUT
+        ERROR_VARIABLE PIP_UPGRADE_ERROR
+    )
+    if(NOT PIP_UPGRADE_RESULT EQUAL 0)
+        message(STATUS "pip upgrade output: ${PIP_UPGRADE_OUTPUT}")
+        message(STATUS "pip upgrade error: ${PIP_UPGRADE_ERROR}")
+        message(WARNING "Failed to upgrade pip, continuing anyway...")
+    endif()
+endif ()

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -8,7 +8,10 @@ set(SPDLOG_VERSION 1.17.0)
 # However, there is a version mismatch between the `fmt` library installed as dependency, and the one actually
 # being required leading to a linking error (i.e. missing symbols) while compiling!
 # Update 29.11.2024: We fixed this by using spdlog has header library (--> top-level CMake file)
-find_package(spdlog ${SPDLOG_VERSION} QUIET)
+if(TARGET spdlog::spdlog)
+    message(STATUS "Found existing spdlog Library target: spdlog::spdlog")
+    return()
+endif()
 
 if(${spdlog_FOUND})
     message(STATUS "Found existing spdlog Library: ${spdlog_DIR}")

--- a/cmake/sphinx.cmake
+++ b/cmake/sphinx.cmake
@@ -1,18 +1,7 @@
 # Adapted from https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/
 
 # Set up a virtual environment variables with Sphinx, Breathe, and sphinx_rtd_theme
-set(VENV_DIR "${CMAKE_SOURCE_DIR}/.venv")
-
-# Cross-platform virtual environment paths
-if(WIN32)
-    set(VENV_BIN_DIR "${VENV_DIR}/Scripts")
-    set(VENV_PYTHON "${VENV_BIN_DIR}/python.exe")
-    set(VENV_SPHINX "${VENV_BIN_DIR}/sphinx-build.exe")
-else()
-    set(VENV_BIN_DIR "${VENV_DIR}/bin")
-    set(VENV_PYTHON "${VENV_BIN_DIR}/python")
-    set(VENV_SPHINX "${VENV_BIN_DIR}/sphinx-build")
-endif()
+include(pyvenv)
 
 function(install_sphinx)
     message(STATUS "Installing Sphinx, Breathe, and sphinx_rtd_theme...")
@@ -50,31 +39,6 @@ function(validate_sphinx_executable)
 endfunction()
 
 function(install_sphinx_virtual)
-    if(NOT EXISTS "${VENV_DIR}")
-        message(STATUS "Creating Python virtual environment at ${VENV_DIR}")
-        find_package(Python3 COMPONENTS Interpreter REQUIRED)
-        execute_process(
-            COMMAND "${Python3_EXECUTABLE}" -m venv "${VENV_DIR}"
-            RESULT_VARIABLE VENV_CREATE_RESULT
-        )
-        if(NOT VENV_CREATE_RESULT EQUAL 0)
-            message(FATAL_ERROR "Failed to create virtual environment")
-        endif()
-
-        # Install required packages
-        execute_process(
-            COMMAND "${VENV_PYTHON}" -m pip install --upgrade pip
-            RESULT_VARIABLE PIP_UPGRADE_RESULT
-            OUTPUT_VARIABLE PIP_UPGRADE_OUTPUT
-            ERROR_VARIABLE PIP_UPGRADE_ERROR
-        )
-        if(NOT PIP_UPGRADE_RESULT EQUAL 0)
-            message(STATUS "pip upgrade output: ${PIP_UPGRADE_OUTPUT}")
-            message(STATUS "pip upgrade error: ${PIP_UPGRADE_ERROR}")
-            message(WARNING "Failed to upgrade pip, continuing anyway...")
-        endif()
-    endif ()
-
     # Prevent stale CMake cache entries from reporting a removed executable as found.
     unset(SPHINX_EXECUTABLE)
     unset(SPHINX_EXECUTABLE CACHE)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_target(Sphinx ALL
 message(STATUS "Installing KDTree package in virtual environment for Sphinx documentation. This may take a moment...")
 
 execute_process(
-    COMMAND ${VENV_PYTHON} -m pip install ${KD_TREE_SOURCE_DIR}
+    COMMAND ${VENV_PYTHON} -m pip install ${KD_TREE_SOURCE_DIR} --config-settings=cmake.args={"--preset","python"} -v
     RESULT_VARIABLE INSTALL_RESULT
     OUTPUT_VARIABLE INSTALL_OUTPUT
     ERROR_VARIABLE INSTALL_ERROR

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -37,11 +37,10 @@ set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
 
 # Sphinx target depends on Recurse_rst
 add_custom_target(Sphinx ALL
-        COMMAND ${SPHINX_EXECUTABLE} -b html
+        COMMAND ${SPHINX_EXECUTABLE} -W -b html
         -Dbreathe_projects.KDTree=${DOXYGEN_OUTPUT_DIR}/xml
         ${SPHINX_SOURCE} ${SPHINX_BUILD}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        DEPENDS
-        Doxygen
+        DEPENDS Doxygen 
         COMMENT "Generating documentation with Sphinx"
 )

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -48,16 +48,17 @@ add_custom_target(Sphinx ALL
 message(STATUS "Installing KDTree package in virtual environment for Sphinx documentation. This may take a moment...")
 
 execute_process(
-    COMMAND ${VENV_PYTHON} -m pip install ${KD_TREE_SOURCE_DIR} --config-settings=cmake.args={"--preset","python"} -v
+    COMMAND ${VENV_PYTHON} -m pip install ${KD_TREE_SOURCE_DIR}
+            --config-settings=cmake.args=--preset
+            --config-settings=cmake.args=python
+            -v
     RESULT_VARIABLE INSTALL_RESULT
     OUTPUT_VARIABLE INSTALL_OUTPUT
     ERROR_VARIABLE INSTALL_ERROR
+    ECHO_OUTPUT_VARIABLE
 )
 
 if(NOT INSTALL_RESULT EQUAL 0)
-    message(STATUS "pip install output: ${INSTALL_OUTPUT}")
     message(STATUS "pip install error: ${INSTALL_ERROR}")
     message(WARNING "Failed to install KDTree package in virtual environment. Python documentation may not work correctly.")
-else()
-    message(STATUS "Successfully installed KDTree package in virtual environment")
 endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -44,3 +44,20 @@ add_custom_target(Sphinx ALL
         DEPENDS Doxygen 
         COMMENT "Generating documentation with Sphinx"
 )
+
+message(STATUS "Installing KDTree package in virtual environment for Sphinx documentation. This may take a moment...")
+
+execute_process(
+    COMMAND ${VENV_PYTHON} -m pip install ${KD_TREE_SOURCE_DIR}
+    RESULT_VARIABLE INSTALL_RESULT
+    OUTPUT_VARIABLE INSTALL_OUTPUT
+    ERROR_VARIABLE INSTALL_ERROR
+)
+
+if(NOT INSTALL_RESULT EQUAL 0)
+    message(STATUS "pip install output: ${INSTALL_OUTPUT}")
+    message(STATUS "pip install error: ${INSTALL_ERROR}")
+    message(WARNING "Failed to install KDTree package in virtual environment. Python documentation may not work correctly.")
+else()
+    message(STATUS "Successfully installed KDTree package in virtual environment")
+endif()

--- a/docs/source/Doxyfile.in
+++ b/docs/source/Doxyfile.in
@@ -1045,47 +1045,7 @@ INPUT_FILE_ENCODING    =
 # provided as Doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-FILE_PATTERNS          = *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
-                         *.h \
-                         *.hh \
-                         *.hxx \
-                         *.hpp \
-                         *.h++ \
-                         *.l \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
-                         *.markdown \
-                         *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f18 \
-                         *.f \
-                         *.for \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf \
-                         *.ice
+FILE_PATTERNS = *.h *.hpp *.py
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/docs/source/Doxyfile.in
+++ b/docs/source/Doxyfile.in
@@ -1045,7 +1045,56 @@ INPUT_FILE_ENCODING    =
 # provided as Doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-FILE_PATTERNS = *.h *.hpp *.py
+FILE_PATTERNS          = *.c \
+                         *.cc \
+                         *.cxx \
+                         *.cxxm \
+                         *.cpp \
+                         *.cppm \
+                         *.ccm \
+                         *.c++ \
+                         *.c++m \
+                         *.java \
+                         *.ii \
+                         *.ixx \
+                         *.ipp \
+                         *.i++ \
+                         *.inl \
+                         *.idl \
+                         *.ddl \
+                         *.odl \
+                         *.h \
+                         *.hh \
+                         *.hxx \
+                         *.hpp \
+                         *.h++ \
+                         *.l \
+                         *.cs \
+                         *.d \
+                         *.php \
+                         *.php4 \
+                         *.php5 \
+                         *.phtml \
+                         *.inc \
+                         *.m \
+                         *.markdown \
+                         *.md \
+                         *.mm \
+                         *.dox \
+                         *.py \
+                         *.pyw \
+                         *.f90 \
+                         *.f95 \
+                         *.f03 \
+                         *.f08 \
+                         *.f18 \
+                         *.f \
+                         *.for \
+                         *.vhd \
+                         *.vhdl \
+                         *.ucf \
+                         *.qsf \
+                         *.ice
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/docs/source/Doxyfile.in
+++ b/docs/source/Doxyfile.in
@@ -1045,16 +1045,7 @@ INPUT_FILE_ENCODING    =
 # provided as Doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cxxm \
-                         *.cpp \
-                         *.cppm \
-                         *.ccm \
-                         *.c++ \
-                         *.c++m \
-                         *.java \
+FILE_PATTERNS          = *.java \
                          *.ii \
                          *.ixx \
                          *.ipp \

--- a/docs/source/cmake/cmake.rst
+++ b/docs/source/cmake/cmake.rst
@@ -1,4 +1,4 @@
-.. _cmake::
+.. _cmake:
 
 CMake Reference
 ===============
@@ -86,7 +86,7 @@ Configure presets (from ``CMakePresets.json``):
 +----------------+-------------------------------+-----------------------------------------------------------+
 | ``release-tbb``| ``release``                   | Release build with TBB backend.                           |
 +----------------+-------------------------------+-----------------------------------------------------------+
-| ``test-release``| ``release-tbb``              | Test build in Release with ``BUILD_KD_TREE_TESTS=ON``.     |
+| ``test-release``| ``release-tbb``              | Test build in Release with ``BUILD_KD_TREE_TESTS=ON``.    |
 +----------------+-------------------------------+-----------------------------------------------------------+
 | ``test-debug`` | ``debug``                     | Test build in Debug with ``BUILD_KD_TREE_TESTS=ON``.      |
 +----------------+-------------------------------+-----------------------------------------------------------+

--- a/docs/source/code_docs/cpp.rst
+++ b/docs/source/code_docs/cpp.rst
@@ -17,6 +17,7 @@ Tree Nodes
 .. doxygenclass:: kdtree::TreeNode
    :project: KDTree
    :members:
+   :undoc-members:
 
 .. doxygenclass:: kdtree::SplitNode
    :project: KDTree

--- a/docs/source/code_docs/cpp.rst
+++ b/docs/source/code_docs/cpp.rst
@@ -17,7 +17,6 @@ Tree Nodes
 .. doxygenclass:: kdtree::TreeNode
    :project: KDTree
    :members:
-   :undoc-members:
 
 .. doxygenclass:: kdtree::SplitNode
    :project: KDTree

--- a/docs/source/code_docs/python.rst
+++ b/docs/source/code_docs/python.rst
@@ -5,3 +5,11 @@ Python Documentation
 
 scikdtree
 ^^^^^^^^^^
+
+.. automodule:: scikdtree.scikdtree
+   :members:
+   :undoc-members:
+
+.. automodule:: scikdtree.plotting
+   :members:
+   :undoc-members:

--- a/docs/source/code_docs/python.rst
+++ b/docs/source/code_docs/python.rst
@@ -1,110 +1,15 @@
 .. _KDTree_py:
 
 Python Documentation
-====================
+======================
 
-.. py:module:: scikdtree
+scikdtree
+^^^^^^^^^^
 
-   Python bindings for the KDTree C++ library, generated via `nanobind <https://nanobind.readthedocs.io>`_.
-   The module is also available at the package level via ``KDTree_Python``.
+.. automodule:: scikdtree.scikdtree
+   :members:
+   :undoc-members:
 
-   .. code-block:: python
-
-      from scikdtree import KDTree, PlaneSelectionAlgorithm
-
-PlaneSelectionAlgorithm
------------------------
-
-.. py:class:: PlaneSelectionAlgorithm
-
-   Enum controlling which split-plane algorithm the KDTree uses during construction.
-
-   .. py:attribute:: LOG
-      :type: PlaneSelectionAlgorithm
-
-      O(n log n) — default, recommended for most use cases.
-
-   .. py:attribute:: LOGSQUARED
-      :type: PlaneSelectionAlgorithm
-
-      O(n log² n) — unoptimised LOG variant, useful for validation and comparison.
-
-   .. py:attribute:: QUADRATIC
-      :type: PlaneSelectionAlgorithm
-
-      O(n²) — suitable only for very small datasets.
-
-   .. py:attribute:: NOTREE
-      :type: PlaneSelectionAlgorithm
-
-      No tree structure is built; falls back to brute-force traversal.
-      Useful as a performance baseline.
-
-KDTree
-------
-
-.. py:class:: KDTree(vertices, faces, algorithm=PlaneSelectionAlgorithm.LOG)
-              KDTree(polySource, algorithm=PlaneSelectionAlgorithm.LOG)
-              KDTree(nodeFilePath, faceFilePath, algorithm=PlaneSelectionAlgorithm.LOG)
-
-   A lazily-built KD-Tree for spatial partitioning of triangle meshes or particle clouds in
-   three-dimensional space. Thread-safe for concurrent intersection queries.
-
-   The tree is built on demand: the root node is only constructed when the first query is made,
-   or explicitly via :py:meth:`prebuildTree`.
-
-   :param vertices: Vertex coordinates of the polyhedron. Each vertex is a list of three floats
-      ``[x, y, z]``.
-   :type vertices: list[list[float]]
-   :param faces: Triangle faces of the polyhedron. Each face is a list of three vertex indices
-      ``[i, j, k]``.
-   :type faces: list[list[int]]
-   :param polySource: A tuple ``(vertices, faces)`` combining both inputs above.
-   :type polySource: tuple[list[list[float]], list[list[int]]]
-   :param nodeFilePath: Path to a Tetgen ``.node`` file containing vertex coordinates.
-   :type nodeFilePath: str
-   :param faceFilePath: Path to a Tetgen ``.face`` file containing triangle indices.
-   :type faceFilePath: str
-   :param algorithm: Split-plane selection algorithm. Defaults to
-      :py:attr:`PlaneSelectionAlgorithm.LOG`.
-   :type algorithm: PlaneSelectionAlgorithm
-
-   .. py:method:: prebuildTree() -> KDTree
-
-      Eagerly constructs the entire KD-Tree instead of building it lazily on the first query.
-      Useful when consistent query latency is required or when the same tree is queried many times.
-
-      :returns: The same ``KDTree`` instance (allows method chaining).
-      :rtype: KDTree
-
-   .. py:method:: countIntersections(origin, ray) -> int
-
-      Counts how many triangles the given ray intersects.
-
-      :param origin: Ray origin as ``[x, y, z]``.
-      :type origin: list[float]
-      :param ray: Ray direction as ``[x, y, z]``.
-      :type ray: list[float]
-      :returns: Number of intersected triangles.
-      :rtype: int
-
-   .. py:method:: getIntersections(origin, ray) -> list[list[float]]
-
-      Returns the exact intersection points of the given ray with the mesh triangles.
-
-      :param origin: Ray origin as ``[x, y, z]``.
-      :type origin: list[float]
-      :param ray: Ray direction as ``[x, y, z]``.
-      :type ray: list[float]
-      :returns: List of intersection points, each as ``[x, y, z]``.
-      :rtype: list[list[float]]
-
-   .. py:method:: printTree() -> None
-
-      Prints the KD-Tree structure to the Python console.
-
-   .. py:method:: __str__() -> str
-
-      Returns a string representation of the KD-Tree structure.
-
-      :rtype: str
+.. automodule:: scikdtree.plotting
+   :members:
+   :undoc-members:

--- a/docs/source/code_docs/python.rst
+++ b/docs/source/code_docs/python.rst
@@ -5,11 +5,3 @@ Python Documentation
 
 scikdtree
 ^^^^^^^^^^
-
-.. automodule:: scikdtree.scikdtree
-   :members:
-   :undoc-members:
-
-.. automodule:: scikdtree.plotting
-   :members:
-   :undoc-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ release = 'v1.0.0'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['sphinx_rtd_theme', 'breathe']
+extensions = ['sphinx_rtd_theme', 'breathe', 'sphinx.ext.autodoc']
 
 templates_path = ['_templates']
 exclude_patterns = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,3 +42,5 @@ html_theme_options = {
     'navigation_depth': 4,
     'sticky_navigation': True,
 }
+
+suppress_warnings = ['duplicate_declaration.cpp']

--- a/docs/source/examples/cpp.rst
+++ b/docs/source/examples/cpp.rst
@@ -47,6 +47,7 @@ In order to build a KDTree operating on particles refer to the following code sn
 To build a KDTree operating on triangle meshes, replace the data definition and KDTree build sections with the following code snippet:
 
 .. code-block::
+   
    // data defintion section
    std::vector<std::array<double, 3>> vertices{
          {2.0, 3.0, 6.0}, {5.0, 4.0, 7.0}, {9.0, 6.0, 1.0},

--- a/docs/source/tests/pytest.rst
+++ b/docs/source/tests/pytest.rst
@@ -8,7 +8,8 @@ Install Test Dependencies
 -------------------------
 
 .. code-block:: bash
-    # optional: create and activate a virtual environment
+   
+   # optional: create and activate a virtual environment
    pip install pytest
 
 Build and Install the Python Module

--- a/src/KDTree/Logging.h
+++ b/src/KDTree/Logging.h
@@ -57,4 +57,4 @@ namespace kdtree {
         KDTreeLogger::defaultLogger().getLogger()->error(msg.str());
     }
 
-} // namespace kdtree
+}// namespace kdtree

--- a/src/KDTree/input/TetgenAdapter.h
+++ b/src/KDTree/input/TetgenAdapter.h
@@ -11,8 +11,8 @@
 #include "KDTree/tree/KdDefinitions.h"
 #include "tetgen.h"
 
-#include "KDTree/util/UtilityContainer.h"
 #include "KDTree/util/Constants.h"
+#include "KDTree/util/UtilityContainer.h"
 #include <array>
 #include <exception>
 #include <functional>
@@ -33,10 +33,10 @@ namespace kdtree {
  */
     class TetgenAdapter {
 
-         /**
+        /**
           * Delegates the call to the library tetgen
           */
-         tetgenio _tetgenio;
+        tetgenio _tetgenio;
 
         /**
          * The file names from which to read in the polyhedron

--- a/src/KDTree/model/Box.cpp
+++ b/src/KDTree/model/Box.cpp
@@ -100,7 +100,7 @@ namespace kdtree {
         using namespace util;
         //the distance is interpreted in the normal direction, negative values are in opposite direction of the normal.
         auto distanceMeasures = [&plane, &flipPlaneNormal](
-                        const Vertex &point) -> double {
+                                        const Vertex &point) -> double {
             // works for arbitrary plane orientations:
             // return dot(point - plane.originPoint(), plane.normal(flipPlaneNormal));
             // only works for axis aligned planes:
@@ -108,7 +108,7 @@ namespace kdtree {
         };
         static constexpr auto isInside = [](const double distance) { return distance >= 0.0; };
         static constexpr auto intersectionPoint = [](const Vertex &from, const Vertex &to, const double distanceFrom,
-                                 const double distanceTo) {
+                                                     const double distanceTo) {
             // solve for t in $ [(t * from + (1-t) * to ) - origin] * normal = 0 $
             // equation explained: search for a point on the plane defined by $ (point - origin) * normal $, where point is linearly interpolated using vectors from and to.
             const double t{distanceTo / (distanceTo - distanceFrom)};

--- a/src/KDTree/model/GeometryObject.cpp
+++ b/src/KDTree/model/GeometryObject.cpp
@@ -3,17 +3,16 @@
 #include <utility>
 
 namespace kdtree {
-    GeometryObject::GeometryObject(IndexVector objVertices, const size_t objIndex, const std::shared_ptr<std::vector<VertexHandle>>& vertices)
+    GeometryObject::GeometryObject(IndexVector objVertices, const size_t objIndex, const std::shared_ptr<std::vector<VertexHandle>> &vertices)
         : objIndex{objIndex}, objVertices{std::move(objVertices)}, _vertices{vertices} {
     }
 
     Vertex GeometryObject::operator[](const size_t index) const {
         const auto &vertices = *_vertices;
         return std::visit(util::overloaded{
-                [&](const Vertex *vertex) { return *vertex; },
-                [&](const Vertex &vertex) { return vertex; }
-            },
-            vertices[objVertices[index]]);
+                                  [&](const Vertex *vertex) { return *vertex; },
+                                  [&](const Vertex &vertex) { return vertex; }},
+                          vertices[objVertices[index]]);
     }
 
     const IndexVector &GeometryObject::getIndexVector() const {

--- a/src/KDTree/model/GeometryObject.h
+++ b/src/KDTree/model/GeometryObject.h
@@ -13,7 +13,7 @@ namespace kdtree {
     /**
      * Allow KDTree data to be dynamic or static to avoid dangling references.
      */
-    using VertexHandle = std::variant<Vertex, const Vertex*>;
+    using VertexHandle = std::variant<Vertex, const Vertex *>;
 
     /**
      * This class contains a collection of vertices, representing the corners of a geometrical shape and provides the abstraction on which the kdtree operates.

--- a/src/KDTree/plane_selection/LogNPlane.cpp
+++ b/src/KDTree/plane_selection/LogNPlane.cpp
@@ -114,8 +114,8 @@ namespace kdtree {
             auto clipped = boundingBox.clipToVoxel(vertices);
             //create split plane anchor points using the bounding box
             const auto [minPoint, maxPoint] = Box::getBoundingBox(clipped);
-                //associate parameters for PlaneEvent creation
-                std::array<std::pair<const Vertex, PlaneEventType>, 2> planeEventParam{
+            //associate parameters for PlaneEvent creation
+            std::array<std::pair<const Vertex, PlaneEventType>, 2> planeEventParam{
                     std::make_pair(minPoint, PlaneEventType::starting),
                     std::make_pair(maxPoint, PlaneEventType::ending)};
             //create planes in each dimension, be careful to cluster similar anchor points together.

--- a/src/KDTree/plane_selection/PlaneEventAlgorithm.cpp
+++ b/src/KDTree/plane_selection/PlaneEventAlgorithm.cpp
@@ -52,7 +52,7 @@ namespace kdtree {
                          [&splitParam, &events, &directions, &eventsMutex](const auto &indexAndVertices) {
                              const auto [index, vertices] = indexAndVertices;
                              //first clip the shapes vertices to the current bounding box and then get the bounding box of the clipped shape -> use the box edges as split plane candidates
-                                 const auto [minPoint, maxPoint] = Box::getBoundingBox<std::vector<Vertex>>(splitParam.boundingBox.clipToVoxel(vertices));
+                             const auto [minPoint, maxPoint] = Box::getBoundingBox<std::vector<Vertex>>(splitParam.boundingBox.clipToVoxel(vertices));
                              std::lock_guard lock(eventsMutex);
                              for (const auto &direction: directions) {
                                  // if the shape is perpendicular to the split direction, generate a planar event with the candidate plane in which the shape lies

--- a/src/KDTree/plane_selection/PlaneSelectionAlgorithm.h
+++ b/src/KDTree/plane_selection/PlaneSelectionAlgorithm.h
@@ -140,6 +140,7 @@ namespace kdtree {
                         std::move(_callbackArgs));
             }
         };
+
     protected:
         /**
        * Evaluates the cost function should the specified bounding box and it's shapes be divided by the specified plane. Used to evaluate possible split planes.

--- a/src/KDTree/plane_selection/SquaredPlane.cpp
+++ b/src/KDTree/plane_selection/SquaredPlane.cpp
@@ -26,8 +26,8 @@ namespace kdtree {
                                  const auto &indexAndVertices) {
                              const auto [index, vertices] = indexAndVertices;
                              //first clip the shapes vertices to the current bounding box and then get the bounding box of the clipped shape -> use the box edges as split plane candidates
-                                 const auto clippedVertices = splitParam.boundingBox.clipToVoxel(vertices);
-                                 const auto [minPoint, maxPoint] = Box::getBoundingBox<std::vector<Vertex>>(clippedVertices);
+                             const auto clippedVertices = splitParam.boundingBox.clipToVoxel(vertices);
+                             const auto [minPoint, maxPoint] = Box::getBoundingBox<std::vector<Vertex>>(clippedVertices);
                              for (const auto planeSurfacePoint: {minPoint, maxPoint}) {
                                  //constructs the plane that goes through a vertex lying on the bounding box of the shape to be checked and spans in a specified direction.
                                  Plane candidatePlane{
@@ -80,9 +80,9 @@ namespace kdtree {
         //transform shapeIndices into the vertices
         auto [begin, end] = transformIterator(boundGeometry.cbegin(), boundGeometry.cend(), splitParam.geometryObjects);
         std::for_each(
-            begin, end,
-            [&splitParam, &split, &index_greater, &index_less, &index_equal](std::pair<size_t, std::vector<Vertex>> pair) {
-                auto [geoIndex, vertices] = std::move(pair);
+                begin, end,
+                [&splitParam, &split, &index_greater, &index_less, &index_equal](std::pair<size_t, std::vector<Vertex>> pair) {
+                    auto [geoIndex, vertices] = std::move(pair);
                     bool less{false}, greater{false};
                     auto clippedVertices = splitParam.boundingBox.clipToVoxel(vertices);
                     for (const auto &vertex: clippedVertices) {

--- a/src/KDTree/tree/KDTree.h
+++ b/src/KDTree/tree/KDTree.h
@@ -14,20 +14,20 @@
 #include <utility>
 #include <vector>
 
-#include "NodeRegister.h"
+#include "KDTree/Logging.h"
 #include "KDTree/input/TetgenAdapter.h"
 #include "KDTree/model/GeometryObject.h"
 #include "KDTree/plane_selection/PlaneSelectionAlgorithm.h"
 #include "KDTree/plane_selection/PlaneSelectionAlgorithmFactory.h"
 #include "KDTree/tree/KdDefinitions.h"
 #include "KDTree/tree/LeafNode.h"
+#include "KDTree/tree/PlaneIterator.h"
 #include "KDTree/tree/SplitNode.h"
 #include "KDTree/tree/SplitParam.h"
 #include "KDTree/tree/TreeNode.h"
 #include "KDTree/tree/TreeNodeFactory.h"
 #include "KDTree/util/UtilityContainer.h"
-#include "KDTree/tree/PlaneIterator.h"
-#include "KDTree/Logging.h"
+#include "KDTree/tree/NodeRegister.h"
 
 namespace kdtree {
     /**
@@ -80,9 +80,9 @@ namespace kdtree {
         * @return the lazily built KDTree.
         */
         KDTree(const std::vector<Vertex> &vertices, const std::vector<IndexVector> &shapes,
-             PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG, bool copyVertices = true);
+               PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG, bool copyVertices = true);
 
-        
+
         /**
          * Constructor overload that allows passing the vertices as a different type than Vertex, as long as they are VertexLike. The constructor will convert the vertices to Vertex by static_casting the coordinates to double. This allows for example to pass vertices with single precision (e.g. std::array<float, 3>) without having to convert them to double precision beforehand. The copyVertices parameter is not available in this overload and defaults to true, as it is not possible to guarantee that the original vertex type outlives the tree when passing a different type.
          * @tparam V The vertex type, which must be VertexLike.
@@ -92,10 +92,11 @@ namespace kdtree {
          * @return the lazily built KDTree.
          */
         template<kdtree::VertexLike V>
-        requires std::is_same_v<V, Vertex>
+            requires std::is_same_v<V, Vertex>
         KDTree(const std::vector<V> &vertices, const std::vector<IndexVector> &shapes,
-            PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG)
-        : KDTree(static_cast<const std::vector<Vertex>&>(vertices), shapes, algorithm, true) {}
+               PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG)
+            : KDTree(static_cast<const std::vector<Vertex> &>(vertices), shapes, algorithm, true) {
+        }
 
         /**
          * Constructor overload for VertexLike vertex types that are not Vertex. Converts the vertices to Vertex by static_casting the coordinates to double. The copyVertices parameter is not available in this overload and defaults to true, as it is not possible to guarantee that the original vertex type outlives the tree when passing a different type.
@@ -106,15 +107,17 @@ namespace kdtree {
          * @return the lazily built KDTree.
          */
         template<kdtree::VertexLike V>
-        requires (!std::is_same_v<V, Vertex>)
+            requires(!std::is_same_v<V, Vertex>)
         KDTree(const std::vector<V> &vertices, const std::vector<IndexVector> &shapes,
-             PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG)
-            : KDTree([&]{
-                std::vector<Vertex> converted{};
-                converted.reserve(vertices.size());
-                for (const auto &v : vertices) converted.emplace_back(Vertex{static_cast<double>(v[0]), static_cast<double>(v[1]), static_cast<double>(v[2])});
-                return converted;
-            }(), shapes, algorithm, true) {}
+               PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG)
+            : KDTree([&] {
+                  std::vector<Vertex> converted{};
+                  converted.reserve(vertices.size());
+                  for (const auto &v: vertices) converted.emplace_back(Vertex{static_cast<double>(v[0]), static_cast<double>(v[1]), static_cast<double>(v[2])});
+                  return converted;
+              }(),
+                     shapes, algorithm, true) {
+        }
 
         /**
          * Constructor overload for building a KDTree with particles instead of shapes. Each particle is represented by a single vertex and the tree will not contain any shapes. This means that the tree can be used to efficiently find the nearest point on a ray to a targeted vertex, but not for example to find ray-triangle intersections.
@@ -129,9 +132,10 @@ namespace kdtree {
          * @param algorithm Specifies which algorithm to use for finding optimal split planes.
          */
         template<kdtree::VertexLike V>
-        requires std::is_same_v<V, Vertex>
+            requires std::is_same_v<V, Vertex>
         explicit KDTree(const std::vector<V> &particles, PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG)
-            : KDTree(static_cast<const std::vector<Vertex>&>(particles), algorithm) {}
+            : KDTree(static_cast<const std::vector<Vertex> &>(particles), algorithm) {
+        }
 
         /**
          * Constructor overload for VertexLike vertex types that are not Vertex. Converts the vertices to Vertex by static_casting the coordinates to double. This allows for example to pass vertices with single precision (e.g. std::array<float, 3>) without having to convert them to double precision beforehand.
@@ -140,9 +144,10 @@ namespace kdtree {
          * @param algorithm Specifies which algorithm to use for finding optimal split planes.
          */
         template<kdtree::VertexLike V>
-        requires (!std::is_same_v<V, Vertex>)
+            requires(!std::is_same_v<V, Vertex>)
         explicit KDTree(const std::vector<V> &particles, PlaneSelectionAlgorithm::Algorithm algorithm = PlaneSelectionAlgorithm::Algorithm::LOG)
-            : KDTree([&]{ std::vector<Vertex> converted{}; converted.reserve(particles.size()); for (const auto &v: particles) converted.emplace_back(Vertex{static_cast<double>(v[0]), static_cast<double>(v[1]), static_cast<double>(v[2])}); return converted;}(), algorithm) {}
+            : KDTree([&] { std::vector<Vertex> converted{}; converted.reserve(particles.size()); for (const auto &v: particles) converted.emplace_back(Vertex{static_cast<double>(v[0]), static_cast<double>(v[1]), static_cast<double>(v[2])}); return converted; }(), algorithm) {
+        }
 
         /**
          * Call to build a KDTree to speed up intersections of rays with a polyhedron's shapes.
@@ -159,8 +164,8 @@ namespace kdtree {
          * @param algorithm Specifies which algorithm to use for finding optimal split planes.
          * @return the lazily built KDTree.
          **/
-         KDTree(std::tuple<std::vector<Vertex>, std::vector<IndexVector>> polySource,
-             PlaneSelectionAlgorithm::Algorithm algorithm);
+        KDTree(std::tuple<std::vector<Vertex>, std::vector<IndexVector>> polySource,
+               PlaneSelectionAlgorithm::Algorithm algorithm);
 
         /**
          * Constructor overload for VertexLike vertex types that are not Vertex. Converts the vertices to Vertex by static_casting the coordinates to double. This allows for example to pass vertices with single precision (e.g. std::array<float, 3>) without having to convert them to double precision beforehand. The copyVertices parameter is not available in this overload and defaults to true, as it is not possible to guarantee that the original vertex type outlives the tree when passing a tuple.
@@ -170,10 +175,11 @@ namespace kdtree {
          * @return the lazily built KDTree.
          */
         template<kdtree::VertexLike V>
-        requires std::is_same_v<V, Vertex>
+            requires std::is_same_v<V, Vertex>
         KDTree(std::tuple<std::vector<V>, std::vector<IndexVector>> polySource,
-            PlaneSelectionAlgorithm::Algorithm algorithm)
-            : KDTree(static_cast<std::tuple<std::vector<Vertex>, std::vector<IndexVector>>&>(polySource), algorithm) {}
+               PlaneSelectionAlgorithm::Algorithm algorithm)
+            : KDTree(static_cast<std::tuple<std::vector<Vertex>, std::vector<IndexVector>> &>(polySource), algorithm) {
+        }
 
         /**
          * Constructor overload for VertexLike vertex types that are not Vertex. Converts the vertices to Vertex by static_casting the coordinates to double. This allows for example to pass vertices with single precision (e.g. std::array<float, 3>) without having to convert them to double precision beforehand. The copyVertices parameter is not available in this overload and defaults to true, as it is not possible to guarantee that the original vertex type outlives the tree when passing a tuple.
@@ -183,13 +189,14 @@ namespace kdtree {
          * @return the lazily built KDTree.
          */
         template<kdtree::VertexLike V>
-        requires (!std::is_same_v<V, Vertex>)
+            requires(!std::is_same_v<V, Vertex>)
         KDTree(std::tuple<std::vector<V>, std::vector<IndexVector>> polySource,
-            PlaneSelectionAlgorithm::Algorithm algorithm)
+               PlaneSelectionAlgorithm::Algorithm algorithm)
             : KDTree(std::tuple<std::vector<Vertex>, std::vector<IndexVector>>{
-                [&]{ auto &vec = std::get<0>(polySource); std::vector<Vertex> c; c.reserve(vec.size()); for (const auto &v: vec) c.emplace_back(Vertex{static_cast<double>(v[0]), static_cast<double>(v[1]), static_cast<double>(v[2])}); return c;}(),
-                std::get<1>(polySource)
-            }, algorithm) {}
+                             [&] { auto &vec = std::get<0>(polySource); std::vector<Vertex> c; c.reserve(vec.size()); for (const auto &v: vec) c.emplace_back(Vertex{static_cast<double>(v[0]), static_cast<double>(v[1]), static_cast<double>(v[2])}); return c; }(),
+                             std::get<1>(polySource)},
+                     algorithm) {
+        }
 
 
         /**

--- a/src/KDTree/tree/KdDefinitions.h
+++ b/src/KDTree/tree/KdDefinitions.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "KDTree/util/UtilityContainer.h"
 #include "KDTree/util/Constants.h"
+#include "KDTree/util/UtilityContainer.h"
 #include "thrust/detail/execution_policy.h"
 #include "thrust/execution_policy.h"
 #include "thrust/system/detail/sequential/for_each.h"
@@ -42,7 +42,7 @@ namespace kdtree {
     /**
      * Allow KDTree data to be dynamic or static to avoid dangling references.
      */
-    using VertexHandle = std::variant<Vertex, const Vertex*>;
+    using VertexHandle = std::variant<Vertex, const Vertex *>;
 
     /**
      * Alias for an array of size 3 (size_t)
@@ -117,10 +117,10 @@ namespace kdtree {
     size_t recursionDepth(size_t nodeId);
 
     template<typename T>
-    const Vertex& asVertex(const T &object) {
+    const Vertex &asVertex(const T &object) {
         if constexpr (std::is_same_v<T, VertexHandle>) {
             // Handle variant: extract either Vertex or pointer to it
-            if (const auto* ptr = std::get_if<const Vertex*>(&object)) {
+            if (const auto *ptr = std::get_if<const Vertex *>(&object)) {
                 return **ptr;
             }
             return std::get<Vertex>(object);
@@ -140,7 +140,8 @@ namespace kdtree {
     */
     template<util::Container C>
     std::pair<Vertex, Vertex> findMinMaxCoordinates(C elements)
-        requires std::is_same_v<typename C::value_type, Vertex> || std::is_same_v<typename C::value_type, VertexHandle> {
+        requires std::is_same_v<typename C::value_type, Vertex> || std::is_same_v<typename C::value_type, VertexHandle>
+    {
         //return empty box centered at the origin if no vertices provided
         if (elements.empty()) {
             return {Vertex{0, 0, 0}, Vertex{0, 0, 0}};

--- a/src/KDTree/tree/LeafNode.cpp
+++ b/src/KDTree/tree/LeafNode.cpp
@@ -16,9 +16,9 @@ namespace kdtree {
 
     bool LeafNode::needTreeRebuild() {
         convertPlaneEventsToGeometry();
-        for (const auto &handle : std::get<ObjectIndexVector>(_splitParam->boundObjects)) {
+        for (const auto &handle: std::get<ObjectIndexVector>(_splitParam->boundObjects)) {
             const GeometryObject &object = _splitParam->geometryObjects[handle];
-            for (const auto &vertex : object.getVertices()) {
+            for (const auto &vertex: object.getVertices()) {
                 // TODO: set tolerance in relation to whole tree
                 if (!_splitParam->boundingBox.isVertexInBox(vertex, constants::EPSILON_VERTEX_BOX_TOLERANCE)) {
                     return true;
@@ -29,7 +29,7 @@ namespace kdtree {
     }
 
     void LeafNode::convertPlaneEventsToGeometry() {
-         if (std::holds_alternative<PlaneEventVector>(_splitParam->boundObjects)) {
+        if (std::holds_alternative<PlaneEventVector>(_splitParam->boundObjects)) {
             std::call_once(_convertedToObjects, [this] {
                 LOG_DEBUG("LeafNode: Converting PlaneEventVector to Geometry for nodeId " + std::to_string(this->nodeId));
                 _splitParam->boundObjects = convertEventsToGeometry(std::get<PlaneEventVector>(_splitParam->boundObjects));
@@ -101,19 +101,19 @@ namespace kdtree {
         return std::nullopt;
     }
 
-     std::optional<Vertex> LeafNode::rayIntersectsPoint(const Vertex &rayOrigin, const Vertex &rayVector, const Vertex &center) {
-         using namespace util;
+    std::optional<Vertex> LeafNode::rayIntersectsPoint(const Vertex &rayOrigin, const Vertex &rayVector, const Vertex &center) {
+        using namespace util;
 
-         // Vector from ray origin to sphere center
-         const Vertex oc = rayOrigin - center;
+        // Vector from ray origin to sphere center
+        const Vertex oc = rayOrigin - center;
 
         // Calculate the nearest intersection point
         const double t = -dot(rayVector, oc) / dot(rayVector, rayVector);
 
         const Vertex intersection = rayOrigin + rayVector * t;
 
-         const double distance = dot(intersection - center, intersection - center);
-         if (distance > constants::EPSILON_RAY_POINT_OFFSET) {
+        const double distance = dot(intersection - center, intersection - center);
+        if (distance > constants::EPSILON_RAY_POINT_OFFSET) {
             return std::nullopt;
         }
 

--- a/src/KDTree/tree/LeafNode.h
+++ b/src/KDTree/tree/LeafNode.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "KDTree/util/Constants.h"
 #include "KDTree/Logging.h"
 #include "KDTree/tree/KdDefinitions.h"
 #include "KDTree/tree/SplitParam.h"
 #include "KDTree/tree/TreeNode.h"
+#include "KDTree/util/Constants.h"
 #include "KDTree/util/UtilityContainer.h"
 #include "KDTree/util/UtilityFloatArithmetic.h"
 #include "thrust/detail/execution_policy.h"
@@ -73,7 +73,7 @@ namespace kdtree {
          * @return
          */
         static std::optional<Vertex> rayIntersectsObject(const Vertex &rayOrigin, const Vertex &rayVector,
-                     const GeometryObject &object);
+                                                         const GeometryObject &object);
 
         /**
          * Möller-Trumbore Algorithm for Ray-Face intersection.
@@ -83,7 +83,7 @@ namespace kdtree {
          * @return
          */
         static std::optional<Vertex> rayIntersectsTriangle(const Vertex &rayOrigin, const Vertex &rayVector,
-                   const std::vector<Vertex> &triangleVertices);
+                                                           const std::vector<Vertex> &triangleVertices);
 
         /**
          * Ray-Point intersection test. Also counts the intersection if the ray passes the point with distance smaller than a specified epsilon.

--- a/src/KDTree/tree/NodeRegister.cpp
+++ b/src/KDTree/tree/NodeRegister.cpp
@@ -2,7 +2,7 @@
 
 #include "LeafNode.h"
 
-namespace kdtree{
+namespace kdtree {
 
     void NodeRegister::registerLeafNode(const std::shared_ptr<LeafNode> &node) {
         std::unique_lock lock(leafNodeMutex);
@@ -27,6 +27,4 @@ namespace kdtree{
             return ptr.expired();
         });
     }
-}
-
-
+}// namespace kdtree

--- a/src/KDTree/tree/NodeRegister.h
+++ b/src/KDTree/tree/NodeRegister.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <vector>
-#include <shared_mutex>
 
 namespace kdtree {
 
@@ -38,6 +38,5 @@ namespace kdtree {
          * accessing invalid weak_ptr control blocks.
          */
         void unregisterLeafNode(const std::shared_ptr<LeafNode> &node);
-
     };
-}
+}// namespace kdtree

--- a/src/KDTree/tree/PlaneIterator.cpp
+++ b/src/KDTree/tree/PlaneIterator.cpp
@@ -13,7 +13,7 @@ namespace kdtree {
         return {node->_plane, node->_boundingBox};
     }
 
-    PlaneIterator & PlaneIterator::operator++() {
+    PlaneIterator &PlaneIterator::operator++() {
         // if the queue is empty no advancements can be made, return immediately
         if (_nodeQueue.empty()) {
             return *this;
@@ -31,16 +31,17 @@ namespace kdtree {
     }
 
     PlaneIterator PlaneIterator::operator++(int) {
-        auto currentState =  PlaneIterator(*this);
+        auto currentState = PlaneIterator(*this);
         this->operator++();
         return currentState;
     }
 
     bool PlaneIterator::operator==(const PlaneIterator &rhs) const {
-        return (_nodeQueue.empty() && rhs._nodeQueue.empty()) || (!_nodeQueue.empty() && !rhs._nodeQueue.empty() && _nodeQueue.front() == rhs._nodeQueue.front());;
+        return (_nodeQueue.empty() && rhs._nodeQueue.empty()) || (!_nodeQueue.empty() && !rhs._nodeQueue.empty() && _nodeQueue.front() == rhs._nodeQueue.front());
+        ;
     }
 
     bool PlaneIterator::operator!=(const PlaneIterator &rhs) const {
         return !(*this == rhs);
     }
-}
+}// namespace kdtree

--- a/src/KDTree/tree/PlaneIterator.h
+++ b/src/KDTree/tree/PlaneIterator.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "KDTree/tree/TreeNode.h"
 #include "KDTree/tree/SplitNode.h"
+#include "KDTree/tree/TreeNode.h"
 
 #include <iterator>
 #include <queue>
@@ -10,9 +10,10 @@ namespace kdtree {
      * This class implements an input iterator for the planes of a KDTree. It performs a breadth-first traversal of the tree and returns the plane and bounding box of each SplitNode it encounters. The iterator is initialized with the root node of the tree and uses a queue to keep track of the nodes to be processed. When the iterator is incremented, it processes the current node, queues its child nodes if they are SplitNodes, and then moves to the next node in the queue. The iteration ends when there are no more nodes to process (i.e., when the queue is empty).
      */
     class PlaneIterator {
-        private:
+    private:
         std::queue<std::shared_ptr<SplitNode>> _nodeQueue{};
-        public:
+
+    public:
         // standard iterator definitions
         using value_type = std::pair<Plane, Box>;
         using reference = value_type;
@@ -22,9 +23,9 @@ namespace kdtree {
         PlaneIterator() = default;
         explicit PlaneIterator(std::shared_ptr<SplitNode> rootNode);
         const_reference operator*() const;
-        PlaneIterator& operator++();
+        PlaneIterator &operator++();
         PlaneIterator operator++(int);
         bool operator==(const PlaneIterator &rhs) const;
         bool operator!=(const PlaneIterator &rhs) const;
     };
-}
+}// namespace kdtree

--- a/src/KDTree/tree/SplitNode.cpp
+++ b/src/KDTree/tree/SplitNode.cpp
@@ -38,7 +38,7 @@ namespace kdtree {
         return node;
     }
 
-        std::vector<std::shared_ptr<TreeNode>> SplitNode::getChildrenForIntersection(
+    std::vector<std::shared_ptr<TreeNode>> SplitNode::getChildrenForIntersection(
             const Vertex &origin, const Vertex &ray, const Vertex &inverseRay) {
         LOG_DEBUG("SplitNode: getChildrenForIntersection called for nodeId ", std::to_string(this->nodeId));
         using namespace kdtree::util;

--- a/src/KDTree/tree/SplitNode.h
+++ b/src/KDTree/tree/SplitNode.h
@@ -18,8 +18,8 @@
 #include "KDTree/tree/SplitParam.h"
 #include "KDTree/tree/TreeNode.h"
 #include "KDTree/tree/TreeNodeFactory.h"
-#include "KDTree/util/UtilityContainer.h"
 #include "KDTree/util/Constants.h"
+#include "KDTree/util/UtilityContainer.h"
 
 namespace kdtree {
     struct SplitParam;

--- a/src/KDTree/tree/SplitParam.h
+++ b/src/KDTree/tree/SplitParam.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "KDTree/tree/NodeRegister.h"
 #include "KDTree/model/Box.h"
 #include "KDTree/model/GeometryObject.h"
 #include "KDTree/model/PlaneEvent.h"
+#include "KDTree/tree/NodeRegister.h"
 
 #include "KDTree/tree/KdDefinitions.h"
 
@@ -41,7 +41,7 @@ namespace kdtree {
         /**
          * The NodeRegister object located in the KDTree that is used to register and track node behavior throughout the tree.
          */
-        NodeRegister& nodeRegister;
+        NodeRegister &nodeRegister;
 
         /**
          * Constructor that initializes all fields. Intended for the use with std::make_unique. See {@link SplitParam} fields for further information.
@@ -64,7 +64,7 @@ namespace kdtree {
                    const Direction splitDirection,
                    const std::shared_ptr<PlaneSelectionAlgorithm> &planeSelectionStrategy, NodeRegister &nodeRegister)
             : geometryObjects{geometryObjects}, boundObjects{boundObjects}, boundingBox{boundingBox},
-              splitDirection{splitDirection}, planeSelectionStrategy{planeSelectionStrategy}, nodeRegister {nodeRegister} {
+              splitDirection{splitDirection}, planeSelectionStrategy{planeSelectionStrategy}, nodeRegister{nodeRegister} {
         }
     };
 }// namespace kdtree

--- a/src/KDTree/util/Constants.h
+++ b/src/KDTree/util/Constants.h
@@ -106,5 +106,4 @@ namespace kdtree::constants {
      */
     constexpr int MAX_EXPONENT_DIFFERENCE = 50;
 
-}  // namespace kdtree
-
+}// namespace kdtree::constants

--- a/src/KDTree/util/UtilityContainer.h
+++ b/src/KDTree/util/UtilityContainer.h
@@ -8,12 +8,12 @@
 
 #pragma once
 
+#include "Constants.h"
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <functional>
 #include <iostream>
-#include "Constants.h"
 #include <numeric>
 #include <set>
 #include <string>
@@ -445,12 +445,12 @@ namespace kdtree::util {
     }
 
     template<typename T>
-    constexpr const T& asRef(const T& value) noexcept {
+    constexpr const T &asRef(const T &value) noexcept {
         return value;
     }
 
     template<typename T>
-    constexpr const T& asRef(const T* ptr) {
+    constexpr const T &asRef(const T *ptr) {
         return *ptr;
     }
 

--- a/src/KDTree/util/UtilityFloatArithmetic.cpp
+++ b/src/KDTree/util/UtilityFloatArithmetic.cpp
@@ -40,20 +40,11 @@ namespace kdtree::util {
         return false;
     }
 
-    // Template Instantations for float and double (required since definition is in .cpp file,
-    //      also makes the static assert not strictly necessary)
-    template bool almostEqualUlps<float>(float lhs, float rhs, int ulpDistance);
-    template bool almostEqualUlps<double>(double lhs, double rhs, int ulpDistance);
-
-
     template<typename FloatType>
     bool almostEqualRelative(FloatType lhs, FloatType rhs, double epsilon) {
         const FloatType diff = std::abs(rhs - lhs);
         const FloatType largerValue = std::max(std::abs(rhs), std::abs(lhs));
         return diff <= largerValue * epsilon;
     }
-
-    template bool almostEqualRelative<float>(float lhs, float rhs, double epsilon);
-    template bool almostEqualRelative<double>(double lhs, double rhs, double epsilon);
 
 }// namespace kdtree::util

--- a/src/KDTreePython/KDTreePython.cpp
+++ b/src/KDTreePython/KDTreePython.cpp
@@ -7,8 +7,8 @@
  * and tree printing utilities.
  */
 
-#include <nanobind/nanobind.h>
 #include <nanobind/make_iterator.h>
+#include <nanobind/nanobind.h>
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/set.h>
 #include <nanobind/stl/string.h>
@@ -16,10 +16,10 @@
 
 #include <spdlog/spdlog.h>
 
-#include "KDTree/tree/KDTree.h"
-#include "KDTree/model/Plane.h"
-#include "KDTree/model/Box.h"
 #include "KDTree/Logging.h"
+#include "KDTree/model/Box.h"
+#include "KDTree/model/Plane.h"
+#include "KDTree/tree/KDTree.h"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -42,31 +42,31 @@ void printTree(const kdtree::KDTree &tree) {
 NB_MODULE(scikdtree, m) {
     using namespace kdtree;
     nb::class_<GeometryObject>(m, "GeometryObject")
-        .def("vertices", &GeometryObject::getVertices, R"doc(Get the corner vertices of the geometry object.)doc")
-        .def("vertex_indices", &GeometryObject::getIndexVector, R"doc(Get the indices of the corner vertices.)doc");
+            .def("vertices", &GeometryObject::getVertices, R"doc(Get the corner vertices of the geometry object.)doc")
+            .def("vertex_indices", &GeometryObject::getIndexVector, R"doc(Get the indices of the corner vertices.)doc");
     // Expose Direction enum to Python
     nb::enum_<Direction>(m, "Direction")
-        .value("X", Direction::X)
-        .value("Y", Direction::Y)
-        .value("Z", Direction::Z);
+            .value("X", Direction::X)
+            .value("Y", Direction::Y)
+            .value("Z", Direction::Z);
     // Expose Plane struct to Python
     nb::class_<Plane>(m, "Plane")
-        .def(nb::init<>())
-        .def_rw("axisCoordinate", &Plane::axisCoordinate)
-        .def_rw("orientation", &Plane::orientation)
-        .def("normal", &Plane::normal, "returnFlipped"_a = false, R"doc(Returns the normal vector for this plane.)doc")
-        .def("originPoint", &Plane::originPoint, R"doc(Returns the origin point of the plane.)doc")
-        .def("rayPlaneIntersection", &Plane::rayPlaneIntersection, "origin"_a, "inverseRay"_a, R"doc(Intersects a ray with the plane.)doc")
-        .def("__eq__", &Plane::operator==);
+            .def(nb::init<>())
+            .def_rw("axisCoordinate", &Plane::axisCoordinate)
+            .def_rw("orientation", &Plane::orientation)
+            .def("normal", &Plane::normal, "returnFlipped"_a = false, R"doc(Returns the normal vector for this plane.)doc")
+            .def("originPoint", &Plane::originPoint, R"doc(Returns the origin point of the plane.)doc")
+            .def("rayPlaneIntersection", &Plane::rayPlaneIntersection, "origin"_a, "inverseRay"_a, R"doc(Intersects a ray with the plane.)doc")
+            .def("__eq__", &Plane::operator==);
     // Expose Box struct to Python
     nb::class_<Box>(m, "Box")
-        .def(nb::init<>())
-        .def_rw("minPoint", &Box::minPoint)
-        .def_rw("maxPoint", &Box::maxPoint)
-        .def("rayBoxIntersection", &Box::rayBoxIntersection, "origin"_a, "inverseRay"_a, R"doc(Calculates the intersection points of a ray and a box.)doc")
-        .def("surfaceArea", &Box::surfaceArea, R"doc(Calculates the surface area of a box.)doc")
-        .def("splitBox", &Box::splitBox, "plane"_a, R"doc(Splits this box into two new boxes.)doc")
-        .def("clipToVoxel", &Box::clipToVoxel, "points"_a, R"doc(Clips vertices to this box.)doc");
+            .def(nb::init<>())
+            .def_rw("minPoint", &Box::minPoint)
+            .def_rw("maxPoint", &Box::maxPoint)
+            .def("rayBoxIntersection", &Box::rayBoxIntersection, "origin"_a, "inverseRay"_a, R"doc(Calculates the intersection points of a ray and a box.)doc")
+            .def("surfaceArea", &Box::surfaceArea, R"doc(Calculates the surface area of a box.)doc")
+            .def("splitBox", &Box::splitBox, "plane"_a, R"doc(Splits this box into two new boxes.)doc")
+            .def("clipToVoxel", &Box::clipToVoxel, "points"_a, R"doc(Clips vertices to this box.)doc");
     // Expose PlaneSelectionAlgorithm enum to Python
     nb::enum_<PlaneSelectionAlgorithm::Algorithm>(m, "PlaneSelectionAlgorithm")
             .value("LOG", PlaneSelectionAlgorithm::Algorithm::LOG)
@@ -83,13 +83,11 @@ NB_MODULE(scikdtree, m) {
             .value("CRITICAL", spdlog::level::critical)
             .value("OFF", spdlog::level::off);
     // Expose KDTree class to Python
-        nb::class_<KDTree>(m, "KDTree")
+    nb::class_<KDTree>(m, "KDTree")
             .def(nb::init<const std::vector<Vertex> &, std::vector<IndexVector> &, const PlaneSelectionAlgorithm::Algorithm>(), "vertices"_a, "faces"_a, "algorithm"_a = PlaneSelectionAlgorithm::Algorithm::LOG)
             .def(nb::init<const std::tuple<std::vector<Vertex>, std::vector<IndexVector>> &, const PlaneSelectionAlgorithm::Algorithm>(), "polySource"_a, "algorithm"_a = PlaneSelectionAlgorithm::Algorithm::LOG)
             .def(nb::init<const std::string &, const std::string &, const PlaneSelectionAlgorithm::Algorithm>(), "nodeFilePath"_a, "faceFilePath"_a, "algorithm"_a = PlaneSelectionAlgorithm::Algorithm::LOG)
-            .def("countIntersections", [](KDTree &self, const Vertex &origin, const Vertex &ray) {
-                return self.countIntersections(origin, ray);
-            }, "origin"_a, "ray"_a, R"doc(Count intersections of a ray with the KDTree.)doc")
+            .def("countIntersections", [](KDTree &self, const Vertex &origin, const Vertex &ray) { return self.countIntersections(origin, ray); }, "origin"_a, "ray"_a, R"doc(Count intersections of a ray with the KDTree.)doc")
             .def("getIntersections", [](KDTree &self, const Vertex &origin, const Vertex &ray) {
             std::set<Vertex> intersections{};
             self.getIntersections(origin, ray, intersections);
@@ -102,18 +100,12 @@ NB_MODULE(scikdtree, m) {
             .def("__str__", [](const KDTree &tree) {
             std::ostringstream os;
             os << tree;
-            return os.str();
-        }, R"doc(String representation of the KDTree.)doc")
-        .def("planes",
-             [m](KDTree &self) {
+            return os.str(); }, R"doc(String representation of the KDTree.)doc")
+            .def("planes", [m](KDTree &self) {
                 auto [begin, end] = self.planeIterator();
-                return nb::make_iterator(m, "plane_iterator", begin, end);
-             }, R"doc(Iterate over the planes in the KDTree.)doc")
-        .def("geometry", [m](KDTree &self) {
+                return nb::make_iterator(m, "plane_iterator", begin, end); }, R"doc(Iterate over the planes in the KDTree.)doc")
+            .def("geometry", [m](KDTree &self) {
             auto [begin, end] = self.geometryIterator();
-            return nb::make_iterator(m, "geometry_iterator", begin, end);
-        }, R"doc(Get the geometry objects of the KDTree.)doc")
-        .def_static("set_loglevel", [](spdlog::level::level_enum level) {
-            kdtree::KDTreeLogger::defaultLogger().getLogger()->set_level(level);
-        }, "level"_a, R"doc(Set the logging level for the KDTree.)doc");
+            return nb::make_iterator(m, "geometry_iterator", begin, end); }, R"doc(Get the geometry objects of the KDTree.)doc")
+            .def_static("set_loglevel", [](spdlog::level::level_enum level) { kdtree::KDTreeLogger::defaultLogger().getLogger()->set_level(level); }, "level"_a, R"doc(Set the logging level for the KDTree.)doc");
 }

--- a/src/KDTreePython/plotting.py
+++ b/src/KDTreePython/plotting.py
@@ -16,7 +16,8 @@ def plot_kd_tree(kdtree: KDTree, title: str = "KDTree", outpath: str = None, sho
         :param outpath: Where to save the resulting plot. If None, the plot will not be saved.
         :param kdtree: The KDTree to plot
         :type kdtree: KDTree
-        :return The resulting matplotlib figure
+
+        :return: The resulting matplotlib figure
         :rtype: plt.Figure
     """
     fig = plt.figure(dpi=800)

--- a/src/KDTreePython/plotting.py
+++ b/src/KDTreePython/plotting.py
@@ -10,14 +10,14 @@ from .scikdtree import KDTree, Direction
 def plot_kd_tree(kdtree: KDTree, title: str = "KDTree", outpath: str = None, show_gui: bool = False, print_to_stdout: bool = True) -> plt.Figure:
     """Plots a 3d KD-Tree using matplotlib
 
-    :param show_gui: Shows the resulting plot in a gui. Attention: this blocks the program until the plot window is closed.
-    :param print_to_stdout: If True, prints the progress of plotting to stdout. Otherwise compute silent. Useful for keeping logs clean.
-    :param title: Sets the title of the plot
-    :param outpath: Where to save the resulting plot. If None, the plot will not be saved.
-    :param kdtree: The KDTree to plot
-    :type kdtree: KDTree
-    :return The resulting matplotlib figure
-    :rtype: plt.Figure
+        :param show_gui: Shows the resulting plot in a gui. Attention: this blocks the program until the plot window is closed.
+        :param print_to_stdout: If True, prints the progress of plotting to stdout. Otherwise compute silent. Useful for keeping logs clean.
+        :param title: Sets the title of the plot
+        :param outpath: Where to save the resulting plot. If None, the plot will not be saved.
+        :param kdtree: The KDTree to plot
+        :type kdtree: KDTree
+        :return The resulting matplotlib figure
+        :rtype: plt.Figure
     """
     fig = plt.figure(dpi=800)
     ax = fig.add_subplot(111, projection='3d')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ namespace {
             }
         }
     }
-}
+}// namespace
 
 int main(int argc, char **argv) {
     using namespace kdtree;
@@ -168,12 +168,12 @@ int main(int argc, char **argv) {
 
         const auto averagePlaneCoordinate = [&statistics](const std::size_t axisIndex) {
             return statistics.axisSplitCounts[axisIndex] == 0
-                       ? 0.0
-                       : statistics.sumPlaneCoordinate[axisIndex] / static_cast<double>(statistics.axisSplitCounts[axisIndex]);
+                           ? 0.0
+                           : statistics.sumPlaneCoordinate[axisIndex] / static_cast<double>(statistics.axisSplitCounts[axisIndex]);
         };
         const auto averageBoxSurfaceArea = statistics.planeCount == 0
-                                               ? 0.0
-                                               : statistics.sumBoxSurfaceArea / static_cast<double>(statistics.planeCount);
+                                                   ? 0.0
+                                                   : statistics.sumBoxSurfaceArea / static_cast<double>(statistics.planeCount);
 
         std::ostringstream summary;
         summary << std::fixed << std::setprecision(6);
@@ -209,7 +209,7 @@ int main(int argc, char **argv) {
             summary << " none\n";
         } else {
             summary << '\n';
-            for (const auto &[depth, count] : statistics.depthHistogram) {
+            for (const auto &[depth, count]: statistics.depthHistogram) {
                 summary << "    depth " << depth << ": " << count << '\n';
             }
         }

--- a/test/model/KDTreeTest.cpp
+++ b/test/model/KDTreeTest.cpp
@@ -22,7 +22,7 @@ namespace kdtree {
     using Algorithm = PlaneSelectionAlgorithm::Algorithm;
 
     // Param tuple used by the parameterized test
-    using ParamType = std::tuple<std::vector<std::array<double,3>>, std::vector<IndexVector>, Algorithm, std::vector<std::array<double,3>>>;
+    using ParamType = std::tuple<std::vector<std::array<double, 3>>, std::vector<IndexVector>, Algorithm, std::vector<std::array<double, 3>>>;
 
     namespace {
         /**
@@ -48,7 +48,7 @@ namespace kdtree {
          * @param rhs Second vertex.
          * @return Squared Euclidean distance between @p lhs and @p rhs.
          */
-        [[nodiscard]] double squaredDistance(const std::array<double,3> &lhs, const std::array<double,3> &rhs) {
+        [[nodiscard]] double squaredDistance(const std::array<double, 3> &lhs, const std::array<double, 3> &rhs) {
             const double dx = lhs[0] - rhs[0];
             const double dy = lhs[1] - rhs[1];
             const double dz = lhs[2] - rhs[2];
@@ -60,7 +60,7 @@ namespace kdtree {
          * @param vertex Vertex to format.
          * @return String in the form [x, y, z].
          */
-        [[nodiscard]] std::string vertexToString(const std::array<double,3> &vertex) {
+        [[nodiscard]] std::string vertexToString(const std::array<double, 3> &vertex) {
             std::ostringstream stream;
             stream << "[" << vertex[0] << ", " << vertex[1] << ", " << vertex[2] << "]";
             return stream.str();
@@ -77,12 +77,12 @@ namespace kdtree {
          * @param expectedPoint Target point that should have been intersected.
          * @return Diagnostic message appended to gtest failure output.
          */
-        [[nodiscard]] std::string closestIntersectionMessage(const std::set<std::array<double,3>> &intersections, const std::array<double,3> &expectedPoint) {
+        [[nodiscard]] std::string closestIntersectionMessage(const std::set<std::array<double, 3>> &intersections, const std::array<double, 3> &expectedPoint) {
             if (intersections.empty()) {
                 return "Closest intersection: <none> (intersection set is empty)";
             }
 
-            const auto closest = std::min_element(intersections.begin(), intersections.end(), [&expectedPoint](const std::array<double,3> &lhs, const std::array<double,3> &rhs) {
+            const auto closest = std::min_element(intersections.begin(), intersections.end(), [&expectedPoint](const std::array<double, 3> &lhs, const std::array<double, 3> &rhs) {
                 return squaredDistance(lhs, expectedPoint) < squaredDistance(rhs, expectedPoint);
             });
 
@@ -97,7 +97,7 @@ namespace kdtree {
         /**
          * A simple cube polyhedron for testing purposes: vertices
          */
-        const std::vector<std::array<double,3>> cube_vertices{
+        const std::vector<std::array<double, 3>> cube_vertices{
                 {-1.0, -1.0, -1.0},
                 {1.0, -1.0, -1.0},
                 {1.0, 1.0, -1.0},
@@ -129,7 +129,7 @@ namespace kdtree {
          * The polyhedron is loaded from files using the TetgenAdapter and stored in a static variable to ensure it is only loaded once. The files should be located in the resources directory and named "Eros_scaled-27000.node" and "Eros_scaled-27000.face".
          * @return A tuple containing the vertices and faces of the big polyhedron.
          */
-        const std::tuple<std::vector<std::array<double,3>>, const std::vector<IndexVector>> &getBigPolyhedron() {
+        const std::tuple<std::vector<std::array<double, 3>>, const std::vector<IndexVector>> &getBigPolyhedron() {
             static const std::vector<std::string> polyhedronNodeFilePath = {
                     std::format("resources/Eros_scaled-{}.node", 27000),
                     std::format("resources/Eros_scaled-{}.face", 27000)};
@@ -152,7 +152,7 @@ namespace kdtree {
          * @param vertices The vertices of the triangle.
          * @return A random point on the surface of the triangle.
          */
-        std::array<double,3> randomPointOnFace(const std::array<std::array<double,3>, 3> &vertices) {
+        std::array<double, 3> randomPointOnFace(const std::array<std::array<double, 3>, 3> &vertices) {
             using namespace util;
             std::uniform_real_distribution<> distrib(0.0, 1.0);
             const double a = distrib(gen);
@@ -169,15 +169,15 @@ namespace kdtree {
          * @param n The number of random points to generate.
          * @return A vector of random points on the surface of the polyhedron.
          */
-        std::vector<std::array<double,3>> generateRandomPointsOnPolyhedron(const std::vector<std::array<double,3>> &vertices,
-                                                             const std::vector<IndexVector> &faces,
-                                                             const size_t n) {
-            std::vector<std::array<double,3>> randomPoints;
+        std::vector<std::array<double, 3>> generateRandomPointsOnPolyhedron(const std::vector<std::array<double, 3>> &vertices,
+                                                                            const std::vector<IndexVector> &faces,
+                                                                            const size_t n) {
+            std::vector<std::array<double, 3>> randomPoints;
             randomPoints.reserve(n);
             for (size_t i = 0; i < n; ++i) {
                 const auto faceIndex = getRandomIndex(faces.size());
                 const auto &verticeIndices = faces.at(faceIndex);
-                std::array<std::array<double,3>, 3> faceVertices{};
+                std::array<std::array<double, 3>, 3> faceVertices{};
                 std::ranges::transform(verticeIndices, faceVertices.begin(),
                                        [&](const auto index) { return vertices.at(index); });
                 randomPoints.push_back(randomPointOnFace(faceVertices));
@@ -363,7 +363,7 @@ namespace kdtree {
     TEST_F(KDTreeTest, IteratorTest) {
         const std::string meshPath = "resources/Eros_scaled-1000";
         KDTree tree{meshPath + ".node", meshPath + ".face"};
-         auto [begin, end] = tree.planeIterator();
+        auto [begin, end] = tree.planeIterator();
         unsigned long iteration = 0;
         std::for_each(begin, end, [&](const auto &entry) {
             const auto &[plane, box] = entry;


### PR DESCRIPTION
* **Improve python docs**
* **Enable LFS in doc action**
* **Transfer venv cmake logic into own module**
* **Add logic to install scikdtree next to sphinx to make python code visible**
* **Started: pre-commit for clang-format (and format code)**
* **Started: Fix cmake python install for docs**
* **Fix doc workflow**
* **Avoid parsing cpp files to reduce duplicates**
* **Less file types**
* **Revert "Avoid parsing cpp files to reduce duplicates"**
* **Debug without scikdtree docs**
* **Revert "Debug without scikdtree docs"**
* **Undoc removed from KDTree**
* **Revert "Undoc removed from KDTree"**
* **Suppress duplicate c++ decl warning**
* **Remove duplicate template declarations**



**Fix image errors in the docs as well as generate the python docs dynamically instead of just displaying static descriptions.**

