### PR TITLE
Respect SPDLOG level of repo including the kd-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,16 +33,10 @@ set(KD_TREE_PARALLELIZATION "CPP" CACHE STRING "Host parallelization chosen by t
  (CPP= Serial, OMP = OpenMP, TBB = Intel Threading Building Blocks")
 set_property(CACHE KD_TREE_PARALLELIZATION PROPERTY STRINGS CPP OMP TBB)
 
-# Set the Logging Level if spdlog has not been found, otherwise keep the existing logging level from the found spdlog library
+# Log level options used in cmake/spdlog.cmake, unless the parent project already defines SPDLOG_ACTIVE_LEVEL
 set(KD_TREE_LOGGING_LEVEL_LIST "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
 set(KD_TREE_LOGGING_LEVEL "INFO" CACHE STRING "Set the Logging level, default (INFO), available options: TRACE, DEBUG, INFO, WARN, ERROR, CRITICAL, OFF")
 set_property(CACHE KD_TREE_LOGGING_LEVEL PROPERTY STRINGS ${KD_TREE_LOGGING_LEVEL_LIST})
-# Convert the logging level string to its corresponding number
-list(FIND KD_TREE_LOGGING_LEVEL_LIST ${KD_TREE_LOGGING_LEVEL} LOGGING_LEVEL_INDEX)
-if (${LOGGING_LEVEL_INDEX} EQUAL -1)
-    message(FATAL_ERROR "Invalid logging level: ${KD_TREE_LOGGING_LEVEL}")
-endif ()
-add_compile_definitions(SPDLOG_ACTIVE_LEVEL=${LOGGING_LEVEL_INDEX})
 
 #########################################################
 # What actually to build? - Options, Versions and Output
@@ -116,12 +110,7 @@ message(STATUS "################################################################
 message(STATUS "KD Tree Version          ${KD_TREE_VERSION}")
 message(STATUS "KD Tree Commit Hash      ${KD_TREE_COMMIT_HASH}")
 message(STATUS "KD Tree Parallelization Backend  ${KD_TREE_PARALLELIZATION}")
-# if spdlog is already found, we do not rebuild it, but rather use the existing one. In this case, we do not set the logging level here, but rather use the one from the found spdlog library
-if(TARGET spdlog::spdlog)
-    message(STATUS "KD Tree Logging Level    EXTERNAL")
-else()
-    message(STATUS "KD Tree Logging Level    ${KD_TREE_LOGGING_LEVEL}")
-endif()
+message(STATUS "KD Tree Logging Level    ${KD_TREE_LOGGING_LEVEL}")
 message(STATUS "#################################################################")
 message(STATUS "KD Tree Documentation    ${BUILD_KD_TREE_DOCS}")
 message(STATUS "KD Tree Library          ${BUILD_KD_TREE_LIBRARY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(KD_TREE_PARALLELIZATION "CPP" CACHE STRING "Host parallelization chosen by t
  (CPP= Serial, OMP = OpenMP, TBB = Intel Threading Building Blocks")
 set_property(CACHE KD_TREE_PARALLELIZATION PROPERTY STRINGS CPP OMP TBB)
 
-# Set the Logging Level
+# Set the Logging Level if spdlog has not been found, otherwise keep the existing logging level from the found spdlog library
 set(KD_TREE_LOGGING_LEVEL_LIST "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
 set(KD_TREE_LOGGING_LEVEL "INFO" CACHE STRING "Set the Logging level, default (INFO), available options: TRACE, DEBUG, INFO, WARN, ERROR, CRITICAL, OFF")
 set_property(CACHE KD_TREE_LOGGING_LEVEL PROPERTY STRINGS ${KD_TREE_LOGGING_LEVEL_LIST})
@@ -116,7 +116,12 @@ message(STATUS "################################################################
 message(STATUS "KD Tree Version          ${KD_TREE_VERSION}")
 message(STATUS "KD Tree Commit Hash      ${KD_TREE_COMMIT_HASH}")
 message(STATUS "KD Tree Parallelization Backend  ${KD_TREE_PARALLELIZATION}")
-message(STATUS "KD Tree Logging Level    ${KD_TREE_LOGGING_LEVEL}")
+# if spdlog is already found, we do not rebuild it, but rather use the existing one. In this case, we do not set the logging level here, but rather use the one from the found spdlog library
+if(TARGET spdlog::spdlog)
+    message(STATUS "KD Tree Logging Level    EXTERNAL")
+else()
+    message(STATUS "KD Tree Logging Level    ${KD_TREE_LOGGING_LEVEL}")
+endif()
 message(STATUS "#################################################################")
 message(STATUS "KD Tree Documentation    ${BUILD_KD_TREE_DOCS}")
 message(STATUS "KD Tree Library          ${BUILD_KD_TREE_LIBRARY}")

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -8,6 +8,29 @@ set(SPDLOG_VERSION 1.17.0)
 # However, there is a version mismatch between the `fmt` library installed as dependency, and the one actually
 # being required leading to a linking error (i.e. missing symbols) while compiling!
 # Update 29.11.2024: We fixed this by using spdlog has header library (--> top-level CMake file)
+
+# Only set the active logging level if the parent project has not already defined it - overriding it here would
+# silently discard a level the parent explicitly chose.
+get_directory_property(_kd_tree_compile_defs COMPILE_DEFINITIONS)
+set(_kd_tree_spdlog_level_predefined FALSE)
+foreach(_kd_tree_def ${_kd_tree_compile_defs})
+    if(_kd_tree_def MATCHES "^SPDLOG_ACTIVE_LEVEL=")
+        set(_kd_tree_spdlog_level_predefined TRUE)
+    endif()
+endforeach()
+
+if(_kd_tree_spdlog_level_predefined)
+    message(WARNING "SPDLOG_ACTIVE_LEVEL is already defined by the parent project - KD_TREE_LOGGING_LEVEL (${KD_TREE_LOGGING_LEVEL}) will be ignored.")
+else()
+    # Convert the logging level string to its corresponding number
+    list(FIND KD_TREE_LOGGING_LEVEL_LIST ${KD_TREE_LOGGING_LEVEL} LOGGING_LEVEL_INDEX)
+    if (${LOGGING_LEVEL_INDEX} EQUAL -1)
+        message(FATAL_ERROR "Invalid logging level: ${KD_TREE_LOGGING_LEVEL}")
+    endif ()
+    # Add the logging level index as a compile definition for the build
+    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=${LOGGING_LEVEL_INDEX})
+endif()
+
 if(TARGET spdlog::spdlog)
     message(STATUS "Found existing spdlog Library target: spdlog::spdlog")
     return()


### PR DESCRIPTION
SPDLOG is not rebuilt if provided by the including repository, thus the KD_TREE_LOGGING_LEVEL has no effect.
Only removed the status message for the KD_TREE_LOGGING_LEVEL as it is misleading. The status message now says 'EXTERNAL' instead.