### PR TITLE
Replace early return with a continue statement

### DIFF
--- a/src/KDTree/plane_selection/PlaneEventAlgorithm.cpp
+++ b/src/KDTree/plane_selection/PlaneEventAlgorithm.cpp
@@ -61,7 +61,7 @@ namespace kdtree {
                                              PlaneEventType::planar,
                                              Plane(minPoint, direction),
                                              index);
-                                     return;
+                                     continue;
                                  }
                                  //else create a starting and ending event consisting of the planes defined by the min and max points of the shape's bounding box.
                                  events.emplace_back(


### PR DESCRIPTION
Due to an early return in a for loop some planar events that should be generated are skipped early.